### PR TITLE
Fixed path with php_extension_conf_path var in Debian

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
 php_conf_path: /etc/php5/apache2
-php_extension_conf_path: /etc/php5/conf.d
+php_extension_conf_path: /etc/php5/apache2/conf.d
 php_apc_conf_filename: 20-apc.ini
 php_packages:
   - php5


### PR DESCRIPTION
The path to php_extension_conf_path variable in Debian systems (Ubuntu) is wrong.
The right path is "/etc/php5/apache2/conf.d" instead of "/etc/php5/conf.d".