### PR TITLE
Allow overriding php_packages in play.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@ php_upload_max_filesize: "64M"
 php_apc_cache_by_default: "1"
 php_apc_shm_size: "96M"
 php_date_timezone: "America/Chicago"
-php_packages: []
 php_enable_webserver: true
 php_webserver_daemon: "httpd"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Define php_packages.
+  set_fact: php_packages="{{ __php_packages | list }}"
+  when: php_packages is not defined
+
 - name: Ensure PHP packages are installed (RedHat).
   yum: >
     name={{ item }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,7 @@
 php_conf_path: /etc/php5/apache2
 php_extension_conf_path: /etc/php5/conf.d
 php_apc_conf_filename: 20-apc.ini
-php_packages:
+__php_packages:
   - php5
   - libapache2-mod-php5
   - php5-mcrypt
@@ -11,6 +11,4 @@ php_packages:
   - php5-curl
   - php5-dev
   - php5-gd
-  - php5-ldap
-  - php-apc
 php_webserver_daemon: "apache2"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 php_conf_path: /etc
 php_extension_conf_path: /etc/php.d
 php_apc_conf_filename: apc.ini
-php_packages:
+__php_packages:
   - ImageMagick
   - php
   - php-cli


### PR DESCRIPTION
The suggested patch would make it possible to set php_packages in host_vars/group_vars etc. This is the only way I know of when using vars_include to support multiple distros. I imitated the naming style from jonhattan who uses it here: https://github.com/sbitmedia/ansible-fail2ban/commit/70a6b594a3d8e6789119751f675cfd593b6f2a3e

Would this be ok for merging? I contemplated about splitting the var to a one with the compulsory ones and other with optionals, but decided not to initially. The list of must haves would probably be rather short...
