### PR TITLE
Added assurance that config directories exist

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,9 @@
   notify: restart webserver
   when: ansible_os_family == 'Debian'
 
+- name: Assures {{ php_conf_path }} directory exists
+  file: path={{ php_conf_path }} state=directory
+
 - name: Place PHP configuration file in place.
   template: >
     src=php.ini.j2
@@ -30,6 +33,9 @@
     owner=root group=root mode=644
   notify: restart webserver
   
+- name: Assures {{ php_extension_conf_path }} directory exists
+  file: path={{ php_extension_conf_path }} state=directory
+
 - name: Place APC configuration file in place.
   template: >
     src=apc.ini.j2


### PR DESCRIPTION
The default Debian php_extension_config_path (/etc/php5/conf.d) didn't exist on Ubuntu Trust so I've added a simple assurance that the directory exists. This will create it if it doesn't already exist.
