### PR TITLE
Renamed php-fpm to php5-fpm

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,8 +5,8 @@
     state: restarted
   when: php_enable_webserver
 
-- name: restart php-fpm
+- name: restart php5-fpm
   service:
-    name: php-fpm
+    name: php5-fpm
     state: restarted
   when: php_enable_php_fpm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,9 +51,9 @@
   when: php_enable_apc
   notify: restart webserver
 
-- name: Ensure php-fpm is started and enabled at boot (if configured).
+- name: Ensure php5-fpm is started and enabled at boot (if configured).
   service:
-    name: php-fpm
+    name: php5-fpm
     state: started
     enabled: yes
   when: php_enable_php_fpm


### PR DESCRIPTION
After looking through preciese and debian stable I can't find any reference to php-fpm, it's actually php5-fpm this fixes it.
