### PR TITLE
php-fpm daemon name is different in Debian based distros like Ubuntu #12

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ php_apc_shm_size: "96M"
 php_date_timezone: "America/Chicago"
 php_enable_webserver: true
 php_webserver_daemon: "httpd"
+php_fpm_daemon: "php-fpm"
 
 php_enable_php_fpm: false
 php_enable_apc: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,6 +7,6 @@
 
 - name: restart php-fpm
   service:
-    name: php-fpm
+    name: "{{ php_fpm_daemon }}"
     state: restarted
   when: php_enable_php_fpm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:
-    name: php-fpm
+    name: "{{ php_fpm_daemon }}"
     state: started
     enabled: yes
   when: php_enable_php_fpm

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -14,3 +14,4 @@ __php_packages:
   - php5-gd
   - php-pear
 php_webserver_daemon: "apache2"
+php_fpm_daemon: "php5-fpm"


### PR DESCRIPTION
```
TASK: [geerlingguy.php | Ensure php-fpm is started and enabled at boot (if configured).] ***
failed: [10.0.3.191] => {"failed": true}
msg: service not found: php-fpm
```

Created a variable for the php-fpm daemon name.
