### PR TITLE
Extension path is wrong for Debian

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
 php_conf_path: /etc/php5/apache2
-php_extension_conf_path: /etc/php5/conf.d
+php_extension_conf_path: /etc/php5/apache2/conf.d
 php_apc_conf_filename: 20-apc.ini
 __php_packages:
   - php5


### PR DESCRIPTION
Currently on Debian, the role will put the extension ini files in: /etc/php5/conf.d

This directory is meant to be used to store the ini files, and then they can be symlinked into /etc/php5/apache2/conf.d to enable them. So just putting them there won't actually enable them.
