### PR TITLE
Enable basic OpCache configuration.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,11 @@ php_apc_shm_size: "96M"
 php_apc_stat: "1"
 php_apc_enable_cli: "0"
 
+# OpCache settings
+php_opcache_enable: 1
+php_opcache_enable_cli: 0
+php_opcache_memory_consumption: 64
+
 # If this is set to false, none of the following options will have any effect.
 # Any and all changes to /etc/php.ini will be your responsibility.
 php_use_managed_ini: true

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -384,3 +384,30 @@ ldap.max_links = -1
 
 [dba]
 ;dba.default_handler=
+
+[opcache]
+opcache.enable={{ php_opcache_enable }}
+opcache.enable_cli={{ php_opcache_enable_cli }}
+opcache.memory_consumption={{ php_opcache_memory_consumption }}
+;opcache.interned_strings_buffer=4
+;opcache.max_accelerated_files=2000
+;opcache.max_wasted_percentage=5
+;opcache.use_cwd=1
+;opcache.validate_timestamps=1
+;opcache.revalidate_freq=2
+;opcache.revalidate_path=0
+;opcache.save_comments=1
+;opcache.load_comments=1
+;opcache.fast_shutdown=0
+;opcache.enable_file_override=0
+;opcache.optimization_level=0xffffffff
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+;opcache.blacklist_filename=
+;opcache.max_file_size=0
+;opcache.consistency_checks=0
+;opcache.force_restart_timeout=180
+;opcache.error_log=
+;opcache.log_verbosity_level=1
+;opcache.preferred_memory_model=
+;opcache.protect_memory=0


### PR DESCRIPTION
Can't install Drupal Commons when using this role because OpCache requirement is 128 and no way to customize.