### PR TITLE
Add option to disable expose_php

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ php_apc_enable_cli: "0"
 # Any and all changes to /etc/php.ini will be your responsibility.
 php_use_managed_ini: true
 
+php_expose_php: "On"
 php_memory_limit: "256M"
 php_max_execution_time: "60"
 php_realpath_cache_size: "32K"

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -30,7 +30,7 @@ zend.enable_gc = On
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;
 
-expose_php = On
+expose_php = {{ php_expose_php }}
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;


### PR DESCRIPTION
I think it's an important setting, specially for security. Since I needed it, I made a pull request at the same time.