### PR TITLE
PHP-FPM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,6 @@ The default values for the HTTP server deamon are `httpd` (used by Apache) for R
 
 (RedHat/CentOS only) If you have enabled any additional repositories (might I suggest geerlingguy.repo-epel or geerlingguy.repo-remi), those repositories can be listed under this variable (e.g. `remi,epel`). This can be handy, as an example, if you want to install the latest version of PHP 5.4, which is in the Remi repository.
 
-### PHP-FPM
-
-PHP-FPM is a simple and robust FastCGI Process Manager for PHP. It can dramatically ease scaling of PHP apps and is the normal way of running PHP-based sites and apps when using a webserver like Nginx (though it can be used with other webservers just as easily).
-
-When using this role with PHP running as `php-fpm` instead of as a process inside a webserver (e.g. Apache's `mod_php`), you need to set the following variable to `true`:
-
-    php_enable_php_fpm: false
-
-You will also need to override the default `php_packages` list and add `php-fpm` (RedHat/CentOS) or `php5-fpm` (Debian/Ubuntu) to the list.
-
-This role does not manage fpm-specific www pool configuration (found in `/etc/php-fpm.d/www.conf` on RedHat/CentOS and `/etc/php5/fpm/pool.d/www.conf` on Debian/Ubuntu), but rather allows you to manage those files on your own. If you change that file, remember to notify the `restart php-fpm` handler so PHP picks up the new settings once in place. Settings like `pm.max_children` and other `pm.*` settings can have a dramatic impact on server performance, and should be tuned specifically for each application and server configuration.
-
 ### php.ini settings
 
     php_use_managed_ini: true
@@ -62,6 +50,73 @@ By default, all the extra defaults below are applied through the php.ini include
     php_expose_php: "On"
 
 Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.
+
+### PHP-FPM
+
+PHP-FPM is a simple and robust FastCGI Process Manager for PHP. It can dramatically ease scaling of PHP apps and is the normal way of running PHP-based sites and apps when using a webserver like Nginx (though it can be used with other webservers just as easily).
+
+When using this role with PHP running as `php-fpm` instead of as a process inside a webserver (e.g. Apache's `mod_php`), you need to set the following variable to `true`:
+
+    php_enable_php_fpm: false
+
+You will also need to override the default `php_packages` list and add `php-fpm` (RedHat/CentOS) or `php5-fpm` (Debian/Ubuntu) to the list.
+
+This role does now have an option to manage fpm-specific www pool configuration (found in `/etc/php-fpm.d/www.conf` on RedHat/CentOS and `/etc/php5/fpm/pool.d/www.conf` on Debian/Ubuntu), but still allows you to manage those files on your own. If you change that file, remember to notify the `restart php-fpm` handler so PHP picks up the new settings once in place. Settings like `pm.max_children` and other `pm.*` settings can have a dramatic impact on server performance, and should be tuned specifically for each application and server configuration.
+
+### PHP-FPM Pool Variables
+
+When using this role to manage your pool for PHP-FPM, you need to set the following variable to `true`:
+
+    php_fpm_use_managed_conf: false
+
+**The following are at least recommended to be _required_ variables if using managed conf**
+
+    php_fpm_user: "apache"
+    php_fpm_group: "apache"
+
+The following are *default* variables
+
+    php_fpm_pool_name: "www"
+    php_fpm_listen: "127.0.0.1:9000"
+    php_fpm_listen_backlog: "-1"
+    php_fpm_listen_allowed_clients: "127.0.0.1"
+    php_fpm_user: "apache"
+    php_fpm_group: "apache"
+    php_fpm_pm: "dynamic"
+    php_fpm_pm_max_children: "50"
+    php_fpm_pm_start_servers: "5"
+    php_fpm_pm_min_spare_servers: "5"
+    php_fpm_pm_max_spare_servers: "35"
+    php_fpm_pm_max_requests: "0"
+    php_fpm_request_terminate_timeout: "0"
+    php_fpm_request_slowlog_timeout: "0"
+    php_fpm_slowlog: "/var/log/php-fpm/www-slow.log"
+    php_fpm_catch_workers_output: "no"
+    php_fpm_security_limit_extensions: ".php"
+
+The following are **optional** variables
+
+    php_fpm_listen_owner
+    php_fpm_listen_group
+    php_fpm_listen_mode
+    php_fpm_status_path
+    php_fpm_ping_path
+    php_fpm_ping_response
+    php_fpm_extra_vars
+
+**php_fpm_extra_vars** allows you to set environment as well as php values and flags. See below for example.
+
+    php_fpm_extra_vars:
+      php_admin_value:
+        error_log: "/var/log/php-fpm/www-error.log"
+      php_admin_flag:
+        log_errors: "on"
+      php_value:
+        "session.save_handler": "files"
+        "session.save_path": "/tmp/php/session"
+        "soap.wsdl_cache_dir": "/tmp/php/wsdlcache"
+      php_flag:
+        display_errors: "stderr"
 
 ### OpCache-related Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,29 @@ php_enablerepo: ""
 php_enable_webserver: true
 
 # Start and enable the PHP fpm service.
+# If this is set to false, none of the following options will have any effect.
 php_enable_php_fpm: false
+# If this is set to false, none of the following options will have any effect.
+# Any and all changes to /etc/php-fpm.d/www.conf will be your responsibility.
+php_fpm_use_managed_conf: true
+php_fpm_pool_name: "www"
+php_fpm_listen: "127.0.0.1:9000"
+php_fpm_listen_backlog: "-1"
+php_fpm_listen_allowed_clients: "127.0.0.1"
+php_fpm_user: "apache"
+php_fpm_group: "apache"
+php_fpm_pm: "dynamic"
+php_fpm_pm_max_children: "50"
+php_fpm_pm_start_servers: "5"
+php_fpm_pm_min_spare_servers: "5"
+php_fpm_pm_max_spare_servers: "35"
+php_fpm_pm_max_requests: "0"
+php_fpm_request_terminate_timeout: "0"
+php_fpm_request_slowlog_timeout: "0"
+php_fpm_slowlog: "/var/log/php-fpm/www-slow.log"
+php_fpm_catch_workers_output: "no"
+php_fpm_security_limit_extensions: ".php"
+
 
 # OpCache settings (useful for PHP >=5.5).
 php_opcache_enabled_in_ini: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,6 +41,17 @@
   when: php_opcache_enable
   notify: restart webserver
 
+- name: Place PHP-FPM pool configuration file in place.
+  template:
+    src: php-fpm.d/www.conf.j2
+    dest: "{{ php_fpm_pool_path }}/www.conf"
+    owner: root
+    group: root
+    mode: 0644
+    follow: yes
+  notify: restart php-fpm
+  when: php_enable_php_fpm and php_fpm_use_managed_conf
+
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:
     name: "{{ php_fpm_daemon }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    follow: true
+    follow: yes
   with_items:
     - "{{ php_conf_path }}"
     - "{{ php_extension_conf_path }}"
@@ -15,6 +15,7 @@
     owner: root
     group: root
     mode: 0644
+    follow: yes
   notify: restart webserver
   when: php_use_managed_ini
 
@@ -24,8 +25,8 @@
     dest: "{{ php_extension_conf_path }}/{{ php_apc_conf_filename }}"
     owner: root
     group: root
-    force: yes
     mode: 0644
+    follow: yes
   when: php_enable_apc
   notify: restart webserver
 
@@ -35,8 +36,8 @@
     dest: "{{ php_extension_conf_path }}/{{ php_opcache_conf_filename }}"
     owner: root
     group: root
-    force: yes
     mode: 0644
+    follow: yes
   when: php_opcache_enable
   notify: restart webserver
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,16 @@
     php_extension_conf_path: "{{ __php_extension_conf_path }}"
   when: php_extension_conf_path is not defined
 
+- name: Define php_fpm_conf_path.
+  set_fact:
+    php_fpm_conf_path: "{{ __php_fpm_conf_path }}"
+  when: php_fpm_conf_path is not defined
+
+- name: Define php_fpm_pool_path.
+  set_fact:
+    php_fpm_pool_path: "{{ __php_fpm_pool_path }}"
+  when: php_fpm_pool_path is not defined
+
 # Setup/install tasks.
 - include: setup-RedHat.yml
   when: (php_install_from_source == false) and (ansible_os_family == 'RedHat')

--- a/templates/php-fpm.d/www.conf.j2
+++ b/templates/php-fpm.d/www.conf.j2
@@ -1,0 +1,56 @@
+[{{ php_fpm_pool_name }}]
+listen = {{ php_fpm_listen }}
+
+listen.backlog = {{ php_fpm_listen_backlog }}
+
+listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}
+
+{% if php_fpm_listen_owner is defined %}
+listen.owner = {{ php_fpm_listen_owner }}
+{% endif %}
+{% if php_fpm_listen_group is defined %}
+listen.group = {{ php_fpm_listen_group }}
+{% endif %}
+{% if php_fpm_listen_mode is defined %}
+listen.mode = {{ php_fpm_listen_mode }}
+{% endif %}
+
+user = {{ php_fpm_user }}
+group = {{ php_fpm_group }}
+
+pm = {{ php_fpm_pm }}
+pm.max_children = {{ php_fpm_pm_max_children }}
+pm.start_servers = {{ php_fpm_pm_start_servers }}
+pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}
+pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}
+pm.max_requests = {{ php_fpm_pm_max_requests }}
+
+{% if php_fpm_status_path is defined %}
+pm.status_path = {{ php_fpm_status_path }}
+{% endif %}
+
+{% if php_fpm_ping_path is defined %}
+ping.path = {{ php_fpm_ping_path }}
+{% endif %}
+
+{% if php_fpm_ping_response is defined %}
+ping.response = {{ php_fpm_ping_response }}
+{% endif %}
+
+request_terminate_timeout = {{ php_fpm_request_terminate_timeout }}
+
+request_slowlog_timeout = {{ php_fpm_request_slowlog_timeout }}
+
+slowlog = {{ php_fpm_slowlog }}
+
+catch_workers_output = {{ php_fpm_catch_workers_output }}
+
+security.limit_extensions = {{ php_fpm_security_limit_extensions }}
+
+{% if php_fpm_extra_vars is defined %}
+{% for blockkey, blockdict in php_fpm_extra_vars.iteritems() %}
+{% for key, value in blockdict.iteritems() %}
+{{ blockkey }}[{{ key }}] = {{ value }}
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -17,6 +17,8 @@ __php_webserver_daemon: "apache2"
 # Vendor-specific configuration paths on Debian/Ubuntu make my brain asplode.
 __php_conf_path: "{{ '/etc/php5' if php_webserver_daemon and php_webserver_daemon != 'apache2' else '/etc/php5/apache2' }}"
 __php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
+__php_fpm_conf_path: "{{ __php_conf_path }}/fpm"
+__php_fpm_pool_path: "{{ __php_fpm_conf_path }}/pool.d"
 
 php_apc_conf_filename: 20-apc.ini
 php_opcache_conf_filename: 05-opcache.ini

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -18,7 +18,9 @@ __php_packages:
 __php_webserver_daemon: "httpd"
 
 __php_conf_path: /etc
-php_extension_conf_path: /etc/php.d
+__php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
+__php_fpm_conf_path: "{{ __php_conf_path }}"
+__php_fpm_pool_path: "{{ __php_fpm_conf_path }}/php-fpm.d"
 
 php_apc_conf_filename: apc.ini
 php_opcache_conf_filename: opcache.ini


### PR DESCRIPTION
Added php-fpm configuration options.

I don't care for some of the logic in the www.conf.j2 template as it stands, but it's something I wanted/needed myself. Debian is currently untested. Open to suggestions.