### PR TITLE
Variable to enable / disable php_allow_url_fopen

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,8 @@ php_upload_max_filesize: "64M"
 php_post_max_size: "32M"
 php_date_timezone: "America/Chicago"
 
+php_allow_url_fopen: "Off"
+
 php_sendmail_path: "/usr/sbin/sendmail -t -i"
 php_short_open_tag: false
 

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -88,7 +88,7 @@ max_file_uploads = 20
 ; Fopen wrappers ;
 ;;;;;;;;;;;;;;;;;;
 
-allow_url_fopen = On
+allow_url_fopen = {{ php_allow_url_fopen }}
 allow_url_include = Off
 
 default_socket_timeout = 60


### PR DESCRIPTION
According to phpsec.org (http://phpsec.org/projects/phpsecinfo/tests/allow_url_fopen.html), php_allow_url_fopen should be disabled for security reasons.

It's also recommended to be disabled for Drupal installations (https://www.drupal.org/requirements/php).

I've created a variable "php_allow_url_fopen" and set the default to "Off". This allows the user to override the value if they desire.

Builds successfully using Travis CI (https://travis-ci.org/csedev/ansible-role-php/jobs/80001558)