### PR TITLE
Add option for opcache blacklist file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ php_opcache_max_wasted_percentage: "5"
 php_opcache_validate_timestamps: "1"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
+php_opcache_blacklist_filename: ""
 
 # APC settings (useful for PHP <5.5).
 php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -11,3 +11,6 @@ opcache.max_wasted_percentage={{ php_opcache_max_wasted_percentage }}
 opcache.validate_timestamps={{ php_opcache_validate_timestamps }}
 opcache.revalidate_freq={{ php_opcache_revalidate_freq }}
 opcache.max_file_size={{ php_opcache_max_file_size }}
+{% if php_opcache_blacklist_filename != '' %}
+opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
+{% endif %}


### PR DESCRIPTION
New config item `php_opcache_blacklist_filename` for defining an opcache blacklist file. The config item is optional.