### PR TITLE
Support modifiyng session.save_handler and session.save_path using variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,8 @@ php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 php_display_errors: "Off"
 php_display_startup_errors: "Off"
 
+php_session_save_handler: "files"
+
 # Install PHP from source (instead of using a package manager) with these vars.
 php_install_from_source: false
 php_source_version: "master"

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -170,7 +170,10 @@ pgsql.log_notice = 0
 bcmath.scale = 0
 
 [Session]
-session.save_handler = files
+session.save_handler = {{ php_session_save_handler }}
+{% if php_session_save_path %}
+    session.save_path = {{ php_session_save_path }}
+{% endif %}
 session.use_cookies = 1
 session.use_only_cookies = 1
 session.name = PHPSESSID


### PR DESCRIPTION
We're using Redis to manage PHP sessions, so I've find the need to define session.save_handler and session.save_path in order to do this. I think it could be useful to include as an available configuration variable. 