### PR TITLE
Changed default opcache filenames to match operating system

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -19,5 +19,5 @@ __php_conf_path: "{{ '/etc/php5' if php_webserver_daemon and php_webserver_daemo
 __php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
 
 __php_apc_conf_filename: 20-apc.ini
-__php_opcache_conf_filename: 05-opcache.ini
+__php_opcache_conf_filename: 20-opcache.ini
 php_fpm_daemon: php5-fpm

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -20,5 +20,5 @@ __php_conf_path: /etc
 php_extension_conf_path: /etc/php.d
 
 __php_apc_conf_filename: apc.ini
-__php_opcache_conf_filename: opcache.ini
+__php_opcache_conf_filename: 10-opcache.ini
 php_fpm_daemon: php-fpm


### PR DESCRIPTION
As mentioned in #57, Debian's php5-common now installs opcache using the filename 20-opcache.ini. Because this role already installed opcache as 05-opcache.ini, this will result in the opcache extension being loaded twice (and lots of pointer errors from PHP). I'd imagine a similar problem would occur with RedHat.

This PR just changes the names to match the the defaults mentioned in #57. Note that if accepted, this is a BC breaking change.
