### PR TITLE
Enable php5-fpm in apache2 configuration

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,0 +1,12 @@
+- name: Ensure php5-fpm config file is installed.
+  template:
+    src: apache2-fpm.j2
+    dest: /etc/apache2/mods-available/php5-fpm.conf
+    mode: 0644
+  when: php_enable_php_fpm and php_webserver_daemon == "apache2" 
+  notify: restart webserver
+
+- name: Ensure php5-fpm config file is activated
+  file: src=../mods-available/php5-fpm.conf dest=/etc/apache2/mods-enabled/php5-fpm.conf state=link  
+  when: php_enable_php_fpm and php_webserver_daemon == "apache2" 
+  notify: restart webserver

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,3 +57,6 @@
 
 # Configure PHP.
 - include: configure.yml
+
+- include: configure-Debian.yml
+  when: (php_install_from_source == false) and (ansible_os_family == 'Debian')

--- a/templates/apache2-fpm.j2
+++ b/templates/apache2-fpm.j2
@@ -1,0 +1,11 @@
+<IfModule mod_fastcgi.c>
+AddHandler php5-fcgi .php
+Action php5-fcgi /php5-fcgi
+Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -socket /var/run/php5-fpm.sock -pass-header Authorization
+
+<Directory /usr/lib/cgi-bin>
+    Require all granted
+</Directory>
+
+</IfModule>


### PR DESCRIPTION
php5-fpm can be installed from binaries nowadays, so I've added the possibility to activate the config in apache via this role. I've chosen to put the configuration in the modules directory for backwards compatibility since Debian changed the conf.d directory to conf-available / conf-enabled. 

The change is only for Debian based systems and is tested with the following variables:

    # Php
    php_packages:
    - php5-fpm
    php_enable_webserver: True
    php_enable_php_fpm: True