### PR TITLE
Allow overriding php_fpm_daemon

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,6 +40,11 @@
   when: php_opcache_enable
   notify: restart webserver
 
+- name: Define php_fpm_daemon.
+  set_fact:
+    php_fpm_daemon: "{{ __php_fpm_daemon }}"
+  when: php_fpm_daemon is not defined
+
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:
     name: "{{ php_fpm_daemon }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -20,4 +20,4 @@ __php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
 
 __php_apc_conf_filename: 20-apc.ini
 __php_opcache_conf_filename: 05-opcache.ini
-php_fpm_daemon: php5-fpm
+__php_fpm_daemon: php5-fpm

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -21,4 +21,4 @@ php_extension_conf_path: /etc/php.d
 
 __php_apc_conf_filename: apc.ini
 __php_opcache_conf_filename: opcache.ini
-php_fpm_daemon: php-fpm
+__php_fpm_daemon: php-fpm


### PR DESCRIPTION
Allow overriding `php_fpm_daemon` in a similar way to other vars.