### PR TITLE
Improve repo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The default values for the HTTP server deamon are `httpd` (used by Apache) for R
 
     php_enablerepo: ""
 
-(RedHat/CentOS only) If you have enabled any additional repositories (might I suggest geerlingguy.repo-epel or geerlingguy.repo-remi), those repositories can be listed under this variable (e.g. `remi,epel`). This can be handy, as an example, if you want to install the latest version of PHP 5.4, which is in the Remi repository.
+(RedHat/CentOS only) If you have enabled any additional repositories (might I suggest [geerlingguy.repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel) or [geerlingguy.repo-remi](https://github.com/geerlingguy/ansible-role-repo-remi)), those repositories can be listed under this variable (e.g. `remi-php56,epel`). This can be handy, as an example, if you want to install the latest version of PHP 5.6, which is in the Remi repository.
 
     php_executable: "php"
 


### PR DESCRIPTION
* add link to referenced roles
* use remi-php56 as example (instead of EOL php 5.4)