### PR TITLE
Made php_fpm_pool_conf_path configurable - for PHP 7.

### DIFF
--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -4,6 +4,11 @@
     php_fpm_daemon: "{{ __php_fpm_daemon }}"
   when: php_fpm_daemon is not defined
 
+- name: Define php_fpm_pool_conf_path.
+  set_fact:
+    php_fpm_pool_conf_path: "{{ __php_fpm_pool_conf_path }}"
+  when: php_fpm_pool_conf_path is not defined
+
 - name: Configure php-fpm pool (if enabled).
   lineinfile:
     dest: "{{ php_fpm_pool_conf_path }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -20,4 +20,4 @@ __php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
 __php_apc_conf_filename: 20-apcu.ini
 __php_opcache_conf_filename: 05-opcache.ini
 __php_fpm_daemon: php5-fpm
-php_fpm_pool_conf_path: "/etc/php5/fpm/pool.d/www.conf"
+__php_fpm_pool_conf_path: "/etc/php5/fpm/pool.d/www.conf"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -23,4 +23,4 @@ php_extension_conf_path: /etc/php.d
 __php_apc_conf_filename: 50-apc.ini
 __php_opcache_conf_filename: 10-opcache.ini
 __php_fpm_daemon: php-fpm
-php_fpm_pool_conf_path: "/etc/php-fpm.d/www.conf"
+__php_fpm_pool_conf_path: "/etc/php-fpm.d/www.conf"


### PR DESCRIPTION
Unfortunately Debian likes to have everything PHP5 related in a PHP5 directory, so in-order to get this role working with PHP 7, yet another path has to be configurable!