### PR TITLE
Fix php_fpm_listen for Debian OS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@ php_enable_webserver: true
 
 # PHP-FPM configuration.
 php_enable_php_fpm: false
-php_fpm_listen: "127.0.0.1:9000"
 php_fpm_listen_allowed_clients: "127.0.0.1"
 php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -21,3 +21,5 @@ __php_apc_conf_filename: 20-apcu.ini
 __php_opcache_conf_filename: 05-opcache.ini
 __php_fpm_daemon: php5-fpm
 __php_fpm_pool_conf_path: "/etc/php5/fpm/pool.d/www.conf"
+
+php_fpm_listen: "unix://var/run/php5-fpm.sock"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -24,3 +24,5 @@ __php_apc_conf_filename: 50-apc.ini
 __php_opcache_conf_filename: 10-opcache.ini
 __php_fpm_daemon: php-fpm
 __php_fpm_pool_conf_path: "/etc/php-fpm.d/www.conf"
+
+php_fpm_listen: "127.0.0.1:9000"


### PR DESCRIPTION
Update the value of `php_fpm_listen` for Debian/Ubuntu servers.