### PR TITLE
Configuration options for PHP session handling.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,11 @@ php_date_timezone: "America/Chicago"
 php_sendmail_path: "/usr/sbin/sendmail -t -i"
 php_short_open_tag: false
 
+php_session_cookie_lifetime: 0
+php_session_gc_probability: 1
+php_session_gc_divisor: 1000
+php_session_gc_maxlifetime: 1440
+
 php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 php_display_errors: "Off"
 php_display_startup_errors: "Off"

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -176,16 +176,16 @@ session.use_only_cookies = 1
 session.name = PHPSESSID
 session.auto_start = 0
 
-session.cookie_lifetime = 0
+session.cookie_lifetime = {{ php_session_cookie_lifetime }}
 session.cookie_path = /
 session.cookie_domain =
 session.cookie_httponly =
 
 session.serialize_handler = php
 
-session.gc_probability = 1
-session.gc_divisor = 1000
-session.gc_maxlifetime = 1440
+session.gc_probability = {{ php_session_gc_probability }}
+session.gc_divisor = {{ php_session_gc_divisor }}
+session.gc_maxlifetime = {{ php_session_gc_maxlifetime }}
 
 session.bug_compat_42 = Off
 session.bug_compat_warn = Off


### PR DESCRIPTION
Proposed changes make it possible to configure session related time limits and session garbage collection parameters in php.ini. For example, on Debian derivatives there is a separate cron job that takes care of cleaning up the session data so disabling the gc makes sense if that's left in place.