### PR TITLE
Closes #53, #60: Fix php.ini not applied for php-fpm on ubuntu

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -14,7 +14,7 @@ __php_packages:
 __php_webserver_daemon: "apache2"
 
 # Vendor-specific configuration paths on Debian/Ubuntu make my brain asplode.
-__php_conf_path: "{{ '/etc/php5' if php_webserver_daemon and php_webserver_daemon != 'apache2' else '/etc/php5/apache2' }}"
+__php_conf_path: "{{ '/etc/php5/fpm' if php_enable_webserver and php_enable_php_fpm else '/etc/php5/apache2' if php_enable_webserver and php_webserver_daemon == 'apache2' else '/etc/php5/cli' }}"
 __php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
 
 __php_apc_conf_filename: 20-apcu.ini


### PR DESCRIPTION
This is a mergable PR for #82. I want to keep the old PR for historical reference in case we need to do similar scenario testing again. This works for all distros:
- Apache with `mod_php`
- Apache with PHP FPM (not on Centos 6 because the test setup is complex, this bug fix doesnt adress centos anyway)
- Nginx with PHP FPM
- No webserver (applies to the CLI php).

I feel this is the best approach as a configuration change and a re-provision would create the new ini only if necessary. Instead of bloating the configs or complicating the role unnecessarily (trying to create apc/opcache ini files for all directories would be a nasty `with_nested` task). 

The docker build for PHP FPM only pass on Ubuntu 14.04 with the custom initctl mentioned [here](https://github.com/geerlingguy/ansible-role-mysql/pull/84#issuecomment-186270022). Ubuntu 12.04 fails in the same way as in the before mentioned task. But the ini directories are the same for both 12.04 and 14.04.

CentoOS 6 tests for Apache with PHP FPM fail because of https://github.com/geerlingguy/drupal-vm/issues/346#issuecomment-171869866

The only questionable addition would be to somehow support `libapache2-mod-fastcgi`. This would mean detecting if the package is installed and if so, creating the `php.ini` in `/etc/php5/cgi/php.ini` instead.