### PR TITLE
Fixes variable name to make it configurable in RedHat

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -18,7 +18,7 @@ __php_packages:
 __php_webserver_daemon: "httpd"
 
 __php_conf_path: /etc
-php_extension_conf_path: /etc/php.d
+__php_extension_conf_path: /etc/php.d
 
 __php_apc_conf_filename: 50-apc.ini
 __php_opcache_conf_filename: 10-opcache.ini


### PR DESCRIPTION
`php_extension_conf_path` overrides the one you configure in your vars.

Changed to `__php_extension_conf_path` as it is in Debian.