### PR TITLE
Enable php modules with php5enmod on Debian.

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,0 +1,10 @@
+---
+- name: Enable APC module.
+  command: >
+    php5enmod apcu
+  when: php_enable_apc
+
+- name: Enable Opcache module.
+  command: >
+    php5enmod opcache
+  when: php_opcache_enable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,3 +65,7 @@
 
 # Configure PHP-FPM.
 - include: configure-fpm.yml
+
+# Configure Debian.
+- include: configure-Debian.yml
+  when: ansible_os_family == 'Debian'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -20,12 +20,10 @@ __php_conf_paths:
   - /etc/php5/cli
 
 __php_extension_conf_paths:
-  - /etc/php5/fpm/conf.d
-  - /etc/php5/apache2/conf.d
-  - /etc/php5/cli/conf.d
+  - /etc/php5/mods-available
 
-__php_apc_conf_filename: 20-apcu.ini
-__php_opcache_conf_filename: 05-opcache.ini
+__php_apc_conf_filename: apcu.ini
+__php_opcache_conf_filename: opcache.ini
 __php_fpm_daemon: php5-fpm
 __php_fpm_conf_path: "/etc/php5/fpm"
 __php_fpm_pool_conf_path: "{{ __php_fpm_conf_path }}/pool.d/www.conf"


### PR DESCRIPTION
As mentioned in #93 this PR follows best practices when enabling PHP modules on Debian.

Changes to module config can be centrally managed from the `mods-available` directory rather than duplicating the `ini` files to each sapi conf directory.

```
Using these maintainer scripts will help get rid of the condition
when the package is removed, but not purged, hence triggering error
messages from php from the fact that it cannot load deleted dynamic
extension.
```