### PR TITLE
Bugfix/php fpm default pool dir check

### DIFF
--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -9,7 +9,12 @@
     php_fpm_pool_conf_path: "{{ __php_fpm_pool_conf_path }}"
   when: php_fpm_pool_conf_path is not defined
 
+- name: Obtain status of {{ php_fpm_pool_conf_path | dirname }}
+  stat: path={{ php_fpm_pool_conf_path | dirname }}
+  register: php_fpm_pool_conf_path_dir_stat
+
 - name: Ensure the default pool directory exists.
+  when: php_fpm_pool_conf_path_dir_stat.stat.islnk is not defined
   file:
     path: "{{ php_fpm_pool_conf_path | dirname }}"
     state: directory


### PR DESCRIPTION
This PR fixes the following error:

`TASK [geerlingguy.php : Ensure the default pool directory exists.] *************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "gid": 0, "group": "root", "mode": "0777", "msg": "/etc/php-fpm.d already exists as a link", "owner": "root", "path": "/etc/php-fpm.d", "size": 27, "state": "link", "uid": 0`