### PR TITLE
Fixes #130 and #48: Tweak and simplify some of the apc and opcache configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.
 
 The OpCache is included in PHP starting in version 5.5, and the following variables will only take effect if the version of PHP you have installed is 5.5 or greater.
 
-    php_opcache_enabled_in_ini: false
-
-When installing Opcache, depending on the system and whether running PHP as a webserver module or standalone via `php-fpm`, you might need the line `extension=opcache.so` in `opcache.ini`. If you need that line added (e.g. you're running `php-fpm`), set this variable to true.
-
     php_opcache_enable: "1"
     php_opcache_enable_cli: "0"
     php_opcache_memory_consumption: "96"
@@ -112,10 +108,6 @@ The platform-specific opcache configuration filename. Generally the default shou
     php_enable_apc: true
 
 Whether to enable APCu. Other APCu variables will be ineffective if this is set to false.
-
-    php_apc_enabled_in_ini: false
-
-When installing APCu, depending on the system and whether running PHP as a webserver module or standalone via `php-fpm`, you might need the line `extension=apc.so` in `apc.ini`. If you need that line added (e.g. you're running `php-fpm`), set this variable to true.
 
     php_apc_shm_size: "96M"
     php_apc_enable_cli: "0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,6 @@ php_fpm_pm_max_spare_servers: 5
 php_executable: "php"
 
 # OpCache settings (useful for PHP >=5.5).
-php_opcache_enabled_in_ini: false
 php_opcache_enable: "1"
 php_opcache_enable_cli: "0"
 php_opcache_memory_consumption: "96"
@@ -32,7 +31,6 @@ php_opcache_blacklist_filename: ""
 
 # APCu settings.
 php_enable_apc: true
-php_apc_enabled_in_ini: false
 php_apc_shm_size: "96M"
 php_apc_enable_cli: "0"
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,6 +19,23 @@
   notify: restart webserver
   when: php_use_managed_ini
 
+- name: Check for PHP-installed APCu configuration file(s)
+  find:
+    paths: "{{ item }}"
+    contains: 'extension(\s+)?=(\s+)?apc[u]?\.so'
+  register: php_installed_apc_confs
+  with_items: "{{ php_extension_conf_paths }}"
+
+- name: Remove any PHP-installed APCu configuration files in favor of role configuration
+  file:
+    path: "{{ item.1.path }}"
+    state: absent
+  when: php_apc_conf_filename != (item.1.path.split('/') | last)
+  with_subelements: 
+    - "{{ php_installed_apc_confs.results }}"
+    - files
+  notify: restart webserver
+
 - name: Place APCu configuration file in place.
   template:
     src: apc.ini.j2
@@ -29,6 +46,23 @@
     mode: 0644
   with_items: "{{ php_extension_conf_paths }}"
   when: php_enable_apc
+  notify: restart webserver
+
+- name: Check for PHP-installed OpCache configuration file(s)
+  find:
+    paths: "{{ item }}"
+    contains: 'zend_extension(\s+)?=(\s+)?opcache\.so'
+  register: php_installed_opcache_confs
+  with_items: "{{ php_extension_conf_paths }}"
+
+- name: Remove any PHP-installed OpCache configuration files in favor of role configuration
+  file:
+    path: "{{ item.1.path }}"
+    state: absent
+  when: php_opcache_conf_filename != (item.1.path.split('/') | last)
+  with_subelements: 
+    - "{{ php_installed_opcache_confs.results }}"
+    - files
   notify: restart webserver
 
 - name: Place OpCache configuration file in place.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -48,6 +48,14 @@
   when: php_enable_apc
   notify: restart webserver
 
+- name: Remove APCu configuration file if disabled
+  file:
+    path: "{{ item }}/{{ php_apc_conf_filename }}"
+    state: absent
+  with_items: "{{ php_extension_conf_paths }}"
+  when: not php_enable_apc
+  notify: restart webserver
+
 - name: Check for PHP-installed OpCache configuration file(s)
   find:
     paths: "{{ item }}"
@@ -75,4 +83,12 @@
     mode: 0644
   with_items: "{{ php_extension_conf_paths }}"
   when: php_opcache_enable
+  notify: restart webserver
+
+- name: Remove OpCache configuration file if disabled
+  file:
+    path: "{{ item }}/{{ php_opcache_conf_filename }}"
+    state: absent
+  with_items: "{{ php_extension_conf_paths }}"
+  when: not php_opcache_enable
   notify: restart webserver

--- a/templates/apc.ini.j2
+++ b/templates/apc.ini.j2
@@ -1,7 +1,5 @@
-{% if php_apc_enabled_in_ini %}
 extension=apcu.so
 extension=apc.so
-{% endif %}
 apc.shm_size={{ php_apc_shm_size }}
 apc.enable_cli={{ php_apc_enable_cli }}
 apc.rfc1867=1

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -1,7 +1,4 @@
-{% if php_opcache_enabled_in_ini %}
 zend_extension=opcache.so
-{% endif %}
-
 opcache.enable={{ php_opcache_enable }}
 opcache.enable_cli={{ php_opcache_enable_cli }}
 opcache.memory_consumption={{ php_opcache_memory_consumption }}


### PR DESCRIPTION
[Related to this issue](https://github.com/geerlingguy/ansible-role-php/issues/130) and [this one](https://github.com/geerlingguy/ansible-role-php/issues/48), I thought some tweaks needed to be made with configuration file management for apc and opcache.  The fix is simply to remove any apc or opcache configuration files that the PHP installation creates in favor of managing the configuration files through this role.

Another change is to remove the variables `php_opcache_enabled_in_ini` and `php_apc_enabled_in_ini` and just rely on the switches `php_opcache_enable` and `php_enable_apc` to create or remove the relevant config files.  I think this should suffice unless I'm missing something.  Just let me know.

For the sake of noting everything related going on the repo, it looks like [this pull request](https://github.com/geerlingguy/ansible-role-php/pull/86) was a attempting to solve a similar issue.