### PR TITLE
Add explicit configuration for php-fpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ When using this role with PHP running as `php-fpm` instead of as a process insid
 
     php_enable_php_fpm: false
 
+The php-fpm process will, by default, start its process based on the above configuration. If, however, you would like to configure php-fpm without starting, set the variables as such:
+
+    php_enable_php_fpm: true
+    php_start_php_fpm: false
+
 If you're using Apache, you can easily get it configured to work with PHP-FPM using the [geerlingguy.apache-php-fpm](https://github.com/geerlingguy/ansible-role-apache-php-fpm) role.
 
     php_fpm_listen: "127.0.0.1:9000"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ php_enable_webserver: true
 
 # PHP-FPM configuration.
 php_enable_php_fpm: false
+php_start_php_fpm: "{{ php_enable_php_fpm }}"
 php_fpm_listen: "127.0.0.1:9000"
 php_fpm_listen_allowed_clients: "127.0.0.1"
 php_fpm_pm_max_children: 50

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,4 +10,4 @@
   service:
     name: "{{ php_fpm_daemon }}"
     state: restarted
-  when: php_enable_php_fpm
+  when: php_start_php_fpm

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -73,4 +73,4 @@
     name: "{{ php_fpm_daemon }}"
     state: started
     enabled: yes
-  when: php_enable_php_fpm
+  when: php_start_php_fpm


### PR DESCRIPTION
If the current `php_enable_php_fpm` variable is set to true, php-fpm
will be both configured and started. This may not be the desired outcome
for those who want to configure php-fpm without starting the process.

Add a new variable, `php_start_php_fpm`, that can be configured to
handle the process behavior. This will set to the value of
`php_enable_php_fpm` by default to maintain backwards compatibility,
but can be modified as desired.
