### PR TITLE
Update Debian.yml

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -13,7 +13,7 @@ __php_packages:
   - php7.0-xml
   - php7.0-mbstring
   - php-sqlite3
-  - php-apcu
+  - php7.0-apcu
 __php_webserver_daemon: "apache2"
 
 # Vendor-specific configuration paths on Debian/Ubuntu make my brain asplode.


### PR DESCRIPTION
php-apcu package doesn't exist, the php7.0-apcu does