### PR TITLE
Make sure we can clone PHP repository using git

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -76,6 +76,10 @@
   failed_when: false
   register: php_installed
 
+- name: Make sure we can clone PHP repository using git.
+  apt: name=git state=present
+  when: php_installed|failed
+
 - name: Clone the PHP repository.
   git:
     repo: https://git.php.net/repository/php-src.git


### PR DESCRIPTION
Straight forward change. I am using php build from source. When I install playbook for plain/clean ubuntu it fails as git cannot clone repo. I have added task to make sure we can clone php repo using git.