### PR TITLE
Add bcmath module for php 7

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 ---
 __php_packages:
+  - php7.0-bcmath
   - php7.0-common
   - php7.0-cli
   - php7.0-dev


### PR DESCRIPTION
Hi Jeff.

I think we need this PHP module to be installed, because it's required for some modules(in my case - I'm just can't install commerce on D8).

(I'm using DrupalVM with Ubuntu 16.04 box)

What do you think?

Thanks.