### PR TITLE
Ensure php-fpm is stopped when defined

### DIFF
--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -74,3 +74,10 @@
     state: started
     enabled: yes
   when: php_enable_php_fpm
+
+- name: Ensure php-fpm is stopped and disable at boot (if configured).
+  service:
+    name: "{{ php_fpm_daemon }}"
+    state: stopped
+    enabled: no
+  when: not php_enable_php_fpm

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -80,4 +80,6 @@
     name: "{{ php_fpm_daemon }}"
     state: stopped
     enabled: no
+  register: php_fpm_daemon_result
+  failed_when: "php_fpm_daemon_result|failed and 'could not find' not in php_fpm_daemon_result.msg"
   when: not php_enable_php_fpm


### PR DESCRIPTION
Ensure that php-fpm is stopped and disabled, once that it already installed on the server.