### PR TITLE
Add php7 zip extension

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -12,6 +12,7 @@ __php_packages:
   - php7.0-opcache
   - php7.0-xml
   - php7.0-mbstring
+  - php7.0-zip
   - php-sqlite3
   - php-apcu
 __php_webserver_daemon: "apache2"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,6 +9,7 @@ __php_packages:
   - php-imap
   - php-ldap
   - php-mbstring
+  - php-zip
   - php-opcache
   - php-pdo
   - php-pear


### PR DESCRIPTION
After i upgrade ansible-role-php latest version, my php version is upgrade to 7.0 in Ubuntu 14.04. But I'm trying to use Composer to install Laravel on Ubuntu 14.04, i get something warning below:

```
Failed to download symfony/finder from dist: The zip extension and unzip command are both missing, skipping. The php.ini used by your command-line PHP is: /etc/php/7.0/cli/php.ini
```

I find that should install zip extension. Laracasts  have a similar [issue](https://laracasts.com/discuss/channels/laravel/zip-php-extension-problem-in-ubuntu-php7?page=1). So i want to add php zip extension.
