### PR TITLE
add support to set custom opcache.so location

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.
 
 The OpCache is included in PHP starting in version 5.5, and the following variables will only take effect if the version of PHP you have installed is 5.5 or greater.
 
+    php_opcache_zend_extension: "opcache.so"
     php_opcache_enable: "1"
     php_opcache_enable_cli: "0"
     php_opcache_memory_consumption: "96"
@@ -109,6 +110,8 @@ The OpCache is included in PHP starting in version 5.5, and the following variab
     php_opcache_max_file_size: "0"
 
 OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
+
+For custom opcache.so location provide full path with `php_opcache_zend_extension`.
 
     php_opcache_conf_filename: [platform-specific]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ php_fpm_pm_max_spare_servers: 5
 php_executable: "php"
 
 # OpCache settings (useful for PHP >=5.5).
+php_opcache_zend_extension: "opcache.so"
 php_opcache_enable: "1"
 php_opcache_enable_cli: "0"
 php_opcache_memory_consumption: "96"

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -1,4 +1,4 @@
-zend_extension=opcache.so
+zend_extension={{ php_opcache_zend_extension }}
 opcache.enable={{ php_opcache_enable }}
 opcache.enable_cli={{ php_opcache_enable_cli }}
 opcache.memory_consumption={{ php_opcache_memory_consumption }}


### PR DESCRIPTION
Here is the original problem for anyone having the same issue: There was this error when trying to run php in Centos7. 
`Failed loading opcache.so:  opcache.so: cannot open shared object file: No such file or directory`

Fixed it by installing php56-php-opcache from remi-php56 repo and specifying full path as zend_extension:
`php_opcache_zend_extension: "/opt/remi/php56/root/usr/lib64/php/modules/opcache.so"`
