### PR TITLE
Changed default value of short_open_tags to Off instead of False

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,7 +61,7 @@ php_allow_url_fopen: "On"
 
 php_sendmail_path: "/usr/sbin/sendmail -t -i"
 php_output_buffering: "4096"
-php_short_open_tag: false
+php_short_open_tag: "Off"
 php_disable_functions: []
 
 php_session_cookie_lifetime: 0


### PR DESCRIPTION
https://secure.php.net/manual/en/ini.core.php#ini.short-open-tag

The value should be "Off" instead of "False". This was changed in the pull request making the variable configurable: https://github.com/geerlingguy/ansible-role-php/pull/7/files