### PR TITLE
skip default PHP-FPM pool creation when requested

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+# Create default pool in php-fpm
+php_fpm_create_default_pool: true
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -41,6 +41,7 @@
     group: root
     mode: 0644
     force: no
+  when: php_fpm_create_default_pool
 
 - name: Configure php-fpm pool (if enabled).
   lineinfile:
@@ -65,7 +66,7 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-  when: php_enable_php_fpm
+  when: php_enable_php_fpm and php_fpm_create_default_pool
   notify: restart php-fpm
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).


### PR DESCRIPTION
In our use-case, we're creating php-fpm pools manually, so we don't need default php-fpm pool.

So I suggest to add `php_fpm_create_default_pool`  option that will disable creating of default pool.