### PR TITLE
PHP-FPM service not enabled on boot on Debian 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
   - distro: fedora24
     playbook: test.yml
     php_version: 5.6
+  - distro: debian8
+    playbook: test.yml
+    php_version: 7.0
   - distro: ubuntu1604
     playbook: test.yml
     php_version: 7.0
@@ -48,6 +51,10 @@ script:
 
   # Ensure PHP configurations have taken effect.
   - docker exec --tty ${container_id} env TERM=xterm php -i | grep 'memory_limit.*192'
+
+  # Check the status of PHP-FPM (but don't fail if not found).
+  - docker exec --tty ${container_id} env TERM=xterm systemctl status php${php_version}-fpm status || true
+  - docker exec --tty ${container_id} env TERM=xterm systemctl status php-fpm status || true
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ script:
   - docker exec --tty ${container_id} env TERM=xterm php -i | grep 'memory_limit.*192'
 
   # Check the status of PHP-FPM (but don't fail if not found).
-  - docker exec --tty ${container_id} env TERM=xterm systemctl status php${php_version}-fpm status || true
-  - docker exec --tty ${container_id} env TERM=xterm systemctl status php-fpm status || true
+  - docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php${php_version}-fpm status || true
+  - docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php-fpm status || true
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,18 @@ script:
   # Ensure PHP configurations have taken effect.
   - docker exec --tty ${container_id} env TERM=xterm php -i | grep 'memory_limit.*192'
 
-  # Check the status of PHP-FPM (but don't fail if not found).
-  - docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php${php_version}-fpm status || true
-  - docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php-fpm status || true
+  # Check the status of PHP-FPM.
+  - |
+    case "${distro}" in
+      "centos7"|"fedora24")
+        docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php-fpm status
+        docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php-fpm status | grep -qF "fpm.service; enabled"
+        ;;
+      "debian8"|"ubuntu1604")
+        docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php${php_version}-fpm status
+        docker exec --tty ${container_id} env TERM=xterm systemctl --no-pager status php${php_version}-fpm status | grep -qF "fpm.service; enabled"
+        ;;
+    esac
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -74,4 +74,5 @@
     name: "{{ php_fpm_daemon }}"
     state: started
     enabled: yes
+    use: service
   when: php_enable_php_fpm

--- a/tests/test-source.yml
+++ b/tests/test-source.yml
@@ -3,6 +3,7 @@
 
   vars:
     php_enable_webserver: false
+    php_enable_php_fpm: true
     php_install_from_source: true
     php_source_clone_dir: /root/php-src
     # Workaround for https://github.com/ansible/ansible-modules-core/issues/5457

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,7 @@
 
   vars:
     php_enable_webserver: false
+    php_enable_php_fpm: true
     php_memory_limit: "192M"
     php_enablerepo: "remi,remi-php70"
     php_install_recommends: no
@@ -13,6 +14,7 @@
       when: ansible_os_family == 'Debian'
       changed_when: false
 
+    # Ubuntu-specific tasks.
     - include_vars: test-vars-ubuntu1204.yml
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '12.04'
 
@@ -23,6 +25,32 @@
     - name: Add repository for PHP 5.6.
       apt_repository: repo='ppa:ondrej/php'
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '12.04'
+
+    # Debian-specific tasks.
+    - name: Add dependencies for PHP versions (Debian).
+      apt:
+        name: "{{ item }}"
+      with_items:
+        - apt-transport-https
+        - ca-certificates
+      when: ansible_distribution == "Debian"
+
+    - name: Add Ondrej Sury's apt key (Debian).
+      apt_key:
+        url: https://packages.sury.org/php/apt.gpg
+        state: present
+      when: ansible_distribution == "Debian"
+
+    - name: Add Ondrej Sury's repo (Debian).
+      apt_repository:
+        repo: "deb https://packages.sury.org/php/ {{ ansible_distribution_release }} main"
+        state: present
+      register: php_ondrej_debian_repo
+      when: ansible_distribution == "Debian"
+
+    - name: Update apt caches after repo is added (Debian).
+      apt: update_cache=yes
+      when: php_ondrej_debian_repo.changed and (ansible_distribution == "Debian")
 
   roles:
     - role: geerlingguy.repo-remi


### PR DESCRIPTION
Just checking what travis says. This particular fix would require Ansible 2.2 and be targeted at Debian only so it's a no go.