### PR TITLE
Add functionality to load php5 modules on Debian systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ _Note: If you're using Debian/Ubuntu, you also need to install `libapache2-mod-f
 
 A list of extra PHP packages to install without overriding the default list.
 
+    php_load_modules: []
+
+A list of modules to load on Debian, if not automatically loaded.
+
     php_enable_webserver: true
 
 If your usage of PHP is tied to a web server (e.g. Apache or Nginx), leave this default value. If you are using PHP server-side or to run some small application, set this value to `false` so this role doesn't attempt to interact with a web server.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ php_packages_state: installed
 php_install_recommends: yes
 
 # Enable PHP5 Modules on Debian if not automatically loaded. (List)
-php_enable_modules: []
+php_load_modules: []
 
 # Set this to false if you're not using PHP with Apache/Nginx/etc.
 php_enable_webserver: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ php_packages_state: installed
 # Whether to install recommended packages. Used only for Debian/Ubuntu.
 php_install_recommends: yes
 
+# Enable PHP5 Modules on Debian if not automatically loaded. (List)
+php_enable_modules: []
+
 # Set this to false if you're not using PHP with Apache/Nginx/etc.
 php_enable_webserver: true
 

--- a/tasks/loadmodules-Debian.yml
+++ b/tasks/loadmodules-Debian.yml
@@ -1,0 +1,7 @@
+---
+- name: Load PHP modules that if not automatically loaded with php5enmod
+  shell: /usr/sbin/php5enmod "{{ item }}"
+  with_items: "{{ php_load_modules|list }}"
+  register: reg_php_load_module
+  changed_when: reg_php_load_module.stdout != ""
+  notify: restart webserver

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,10 @@
   when: (php_install_from_source == false) and (ansible_os_family == 'Debian')
   static: no
 
+# Load PHP5 Modules
+- include: "loadmodules-{{ansible_os_family}}.yml"
+  when: php_load_modules|length > 0
+
 # Install PHP from source when php_install_from_source is true.
 - include: install-from-source.yml
   when: php_install_from_source == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,8 +58,8 @@
   static: no
 
 # Load PHP5 Modules
-- include: "loadmodules-{{ansible_os_family}}.yml"
-  when: php_load_modules|length > 0
+- include: "loadmodules-Debian.yml"
+  when: (php_load_modules|length > 0) and (ansible_os_family == 'Debian')
 
 # Install PHP from source when php_install_from_source is true.
 - include: install-from-source.yml


### PR DESCRIPTION
On Debian derivates mcrypt is not automatically loaded. So I wrote a task to enable loading of php modules. I hope that will fit in your role