### PR TITLE
Fix handler checkmode failure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,10 +4,10 @@
     name: "{{ php_webserver_daemon }}"
     state: restarted
   notify: restart php-fpm
-  when: php_enable_webserver
+  when: php_enable_webserver and not ansible_check_mode
 
 - name: restart php-fpm
   service:
     name: "{{ php_fpm_daemon }}"
     state: restarted
-  when: php_enable_php_fpm
+  when: php_enable_php_fpm and not ansible_check_mode


### PR DESCRIPTION
If you run this module in check mode prior to nginx and php-fpm being installed, these two handlers will cause the role to fail.

This fixes that.  Note that this is similar to https://github.com/geerlingguy/ansible-role-nginx/pull/121/files that I just submitted.