### PR TITLE
Support opcache.fast_shutdown config param

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_fast_shutdown: "1"
 
 # APCu settings.
 php_enable_apc: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
-php_opcache_fast_shutdown: "1"
+php_opcache_fast_shutdown: "0"
 
 # APCu settings.
 php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -9,6 +9,7 @@ opcache.validate_timestamps={{ php_opcache_validate_timestamps }}
 opcache.revalidate_path={{ php_opcache_revalidate_path }}
 opcache.revalidate_freq={{ php_opcache_revalidate_freq }}
 opcache.max_file_size={{ php_opcache_max_file_size }}
+opcache.fast_shutdown={{ php_opcache_fast_shutdown }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}


### PR DESCRIPTION
Especially useful in situations where Opcache causes Apache to segfault when this directive is enabled