### PR TITLE
Allow extra config vars for php-fpm pool

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,26 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+php_fpm_config_lines:
+  - regexp: "^user.?=.+$"
+    line: "user = {{ php_fpm_pool_user }}"
+  - regexp: "^group.?=.+$"
+    line: "group = {{ php_fpm_pool_group }}"
+  - regexp: "^listen.?=.+$"
+    line: "listen = {{ php_fpm_listen }}"
+  - regexp: '^listen\.allowed_clients.?=.+$'
+    line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
+  - regexp: '^pm\.max_children.?=.+$'
+    line: "pm.max_children = {{ php_fpm_pm_max_children }}"
+  - regexp: '^pm\.start_servers.?=.+$'
+    line: "pm.start_servers = {{ php_fpm_pm_start_servers }}"
+  - regexp: '^pm\.min_spare_servers.?=.+$'
+    line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
+  - regexp: '^pm\.max_spare_servers.?=.+$'
+    line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
+# Extra config settings for the php-fpm pool
+php_fpm_config_lines_extra: []
+
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -49,23 +49,7 @@
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
-  with_items:
-    - regexp: "^user.?=.+$"
-      line: "user = {{ php_fpm_pool_user }}"
-    - regexp: "^group.?=.+$"
-      line: "group = {{ php_fpm_pool_group }}"
-    - regexp: "^listen.?=.+$"
-      line: "listen = {{ php_fpm_listen }}"
-    - regexp: '^listen\.allowed_clients.?=.+$'
-      line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
-    - regexp: '^pm\.max_children.?=.+$'
-      line: "pm.max_children = {{ php_fpm_pm_max_children }}"
-    - regexp: '^pm\.start_servers.?=.+$'
-      line: "pm.start_servers = {{ php_fpm_pm_start_servers }}"
-    - regexp: '^pm\.min_spare_servers.?=.+$'
-      line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
-    - regexp: '^pm\.max_spare_servers.?=.+$'
-      line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
+  with_items: "{{ php_fpm_config_lines + php_fpm_config_lines_extra }}"
   when: php_enable_php_fpm
   notify: restart php-fpm
 


### PR DESCRIPTION
Allows deployers to set extra config lines in the php-fpm pool settings (ie. status/ping URIs)