### PR TITLE
Adding support for Ondrej's PHP PPA for Ubuntu OS to this playbook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ If you have enabled any additional repositories such as [geerlingguy.repo-epel](
 
 (Debian/Ubuntu only) Whether to install recommended packages when installing `php_packages`; you might want to set this to `no` explicitly if you're installing a PPA that recommends certain packages you don't want (e.g. Ondrej's `php` PPA will install `php7.0-cli` if you install `php-pear` alongside `php5.6-cli`... which is often not desired!).
 
+    php_ppa_use: false
+
+(Ubuntu only) If you would like to enable the Ondrej's `php` PPA. This option is disabled by default.
+
+    php_version: "7.0"
+
+(Ubuntu only) This option combined with the Ondrej's `php` PPA option enables you to specify which version of `php` will be installed. It defaults to the Debian `php` version which is set in the `__php_version` variable. 
+
     php_executable: "php"
 
 The executable to run when calling PHP from the command line. You should only change this if running `php` on your server doesn't target the correct executable, or if you're using software collections on RHEL/CentOS and need to target a different version of PHP.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,11 @@
 # for RHEL/CentOS.
 php_enablerepo: ""
 
+#
+# Use the Ondrej's PHP PPA for Ubuntu only.
+php_ppa_use: false
+php_ppa_name: "ppa:ondrej/php"
+
 # PHP package state; use 'installed' to make sure it's installed, or 'latest' if
 # you want to upgrade or switch versions using a new repo.
 php_packages_state: installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,10 @@
   when: (php_install_from_source == false) and (ansible_os_family == 'RedHat')
   static: no
 
+- include: setup-Ubuntu.yml
+  when: (php_install_from_source == false) and (ansible_distribution == 'Ubuntu')
+  static: no
+
 - include: setup-Debian.yml
   when: (php_install_from_source == false) and (ansible_os_family == 'Debian')
   static: no

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,0 +1,14 @@
+---
+- name: Add PPA for PHP.
+  apt_repository:
+    repo: "{{ php_ppa_name }}"
+    state: present
+    update_cache: yes
+  register: php_ppa_added
+  when: php_ppa_use
+
+- name: Ensure php will reinstall if the PPA was just added.
+  apt:
+    name: "php*"
+    state: absent
+  when: php_ppa_added.changed

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,36 +1,39 @@
 ---
+
+__php_version: "{{ php_version | default('7.0') }}"
+
 __php_packages:
-  - php7.0-common
-  - php7.0-cli
-  - php7.0-dev
-  - php7.0-fpm
-  - libpcre3-dev
-  - php7.0-gd
-  - php7.0-curl
-  - php7.0-imap
-  - php7.0-json
-  - php7.0-opcache
-  - php7.0-xml
-  - php7.0-mbstring
-  - php-sqlite3
-  - php-apcu
+  - "php{{ __php_version }}-common"
+  - "php{{ __php_version }}-cli"
+  - "php{{ __php_version }}-dev"
+  - "php{{ __php_version }}-fpm"
+  - "libpcre3-dev"
+  - "php{{ __php_version }}-gd"
+  - "php{{ __php_version }}-curl"
+  - "php{{ __php_version }}-imap"
+  - "php{{ __php_version }}-json"
+  - "php{{ __php_version }}-opcache"
+  - "php{{ __php_version }}-xml"
+  - "php{{ __php_version }}-mbstring"
+  - "php-sqlite3"
+  - "php-apcu"
 __php_webserver_daemon: "apache2"
 
 # Vendor-specific configuration paths on Debian/Ubuntu make my brain asplode.
 __php_conf_paths:
-  - /etc/php/7.0/fpm
-  - /etc/php/7.0/apache2
-  - /etc/php/7.0/cli
+  - "/etc/php/{{ __php_version }}/fpm"
+  - "/etc/php/{{ __php_version }}/apache2"
+  - "/etc/php/{{ __php_version }}/cli"
 
 __php_extension_conf_paths:
-  - /etc/php/7.0/fpm/conf.d
-  - /etc/php/7.0/apache2/conf.d
-  - /etc/php/7.0/cli/conf.d
+  - "/etc/php/{{ __php_version }}/fpm/conf.d"
+  - "/etc/php/{{ __php_version }}/apache2/conf.d"
+  - "/etc/php/{{ __php_version }}/cli/conf.d"
 
 __php_apc_conf_filename: 20-apcu.ini
 __php_opcache_conf_filename: 05-opcache.ini
-__php_fpm_daemon: php7.0-fpm
-__php_fpm_conf_path: "/etc/php/7.0/fpm"
+__php_fpm_daemon: "php{{ __php_version }}-fpm"
+__php_fpm_conf_path: "/etc/php/{{ __php_version }}/fpm"
 __php_fpm_pool_conf_path: "{{ __php_fpm_conf_path }}/pool.d/www.conf"
 
 __php_fpm_pool_user: www-data


### PR DESCRIPTION
It is possible to install the ppa using the variable

	php_ppa_use: true

It is also now possible to change the PHP version to install under Ubuntu by specifying the variable

	php_version: "7.1"

As left default version to the Debian version which is at the moment 7.0.
I wrote the change in this playbook using the same strategy that has been used in the role `ansible-role-nginx`.