### PR TITLE
Replace PHP-FPM config regex with variables/template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,15 @@ php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 php_fpm_pm_max_requests: 0
+slowlog: "/var/log/php-fpm/www-slow.log"
+php_admin_value:
+  error_log: "/var/log/php-fpm/www-error.log"
+php_admin_flag:
+  log_errors: "on"
+php_value:
+  session.save_handler: "files"
+  session.save_path: "/var/lib/php/fpm/session"
+  soap.wsdl_cache_dir: "/var/lib/php/fpm/wsdlcache"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -40,32 +40,7 @@
     owner: root
     group: root
     mode: 0644
-    force: no
-  when: php_enable_php_fpm
-
-- name: Configure php-fpm pool (if enabled).
-  lineinfile:
-    dest: "{{ php_fpm_pool_conf_path }}"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-    state: present
-  with_items:
-    - regexp: "^user.?=.+$"
-      line: "user = {{ php_fpm_pool_user }}"
-    - regexp: "^group.?=.+$"
-      line: "group = {{ php_fpm_pool_group }}"
-    - regexp: "^listen.?=.+$"
-      line: "listen = {{ php_fpm_listen }}"
-    - regexp: '^listen\.allowed_clients.?=.+$'
-      line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
-    - regexp: '^pm\.max_children.?=.+$'
-      line: "pm.max_children = {{ php_fpm_pm_max_children }}"
-    - regexp: '^pm\.start_servers.?=.+$'
-      line: "pm.start_servers = {{ php_fpm_pm_start_servers }}"
-    - regexp: '^pm\.min_spare_servers.?=.+$'
-      line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
-    - regexp: '^pm\.max_spare_servers.?=.+$'
-      line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
+    force: yes
   when: php_enable_php_fpm
   notify: restart php-fpm
 

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -10,3 +10,22 @@ pm.start_servers = {{ php_fpm_pm_start_servers }}
 pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}
 pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}
 pm.max_requests = {{ php_fpm_pm_max_requests }}
+
+{% if slowlog is defined %}
+slowlog = /var/log/php-fpm/www-slow.log
+{% endif %}
+{% if php_admin_value is defined %}
+{% for value in php_admin_value %}
+php_admin_value[{{ value }}] = {{ php_admin_value[value] }}
+{% endfor %}
+{% endif %}
+{% if php_admin_flag is defined %}
+{% for flag in php_admin_flag %}
+php_admin_flag[{{ flag }}] = {{ php_admin_flag[flag] }}
+{% endfor %}
+{% endif %}
+{% if php_value is defined %}
+{% for value in php_value %}
+php_value[{{ value }}] = {{ php_value[value] }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
The PHP-FPM pool config template is currently unused and somewhat incomplete.  This adds the needed default configuration to the pool config template and tells it to use the defaults from `variables/main.yaml`.

By default it produces an /etc/php-fpm.d/www.conf like this:
```
[www]
listen = 127.0.0.1:9000
listen.allowed_clients = 127.0.0.1
user = apache
group = apache

pm = dynamic
pm.max_children = 50
pm.start_servers = 5
pm.min_spare_servers = 5
pm.max_spare_servers = 5
pm.max_requests = 0

slowlog = /var/log/php-fpm/www-slow.log
php_admin_value[error_log] = /var/log/php-fpm/www-error.log
php_admin_flag[log_errors] = on
php_value[session.save_path] = /var/lib/php/fpm/session
php_value[session.save_handler] = files
php_value[soap.wsdl_cache_dir] = /var/lib/php/fpm/wsdlcache
```