### PR TITLE
Adding variable support for precision and serialize_precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ By default, all the extra defaults below are applied through the php.ini include
     php_sendmail_path: "/usr/sbin/sendmail -t -i"
     php_output_buffering: "4096"
     php_short_open_tag: false
+    php_precision: 14
+    php_serialize_precision: 17
     php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
     php_display_errors: "Off"
     php_display_startup_errors: "On"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ php_executable: "php"
 
 # OpCache settings.
 php_opcache_zend_extension: "opcache.so"
-php_opcache_enable: "1"
+php_opcache_enable: "0"
 php_opcache_enable_cli: "0"
 php_opcache_memory_consumption: "96"
 php_opcache_interned_strings_buffer: "16"
@@ -43,6 +43,11 @@ php_opcache_blacklist_filename: ""
 php_enable_apc: true
 php_apc_shm_size: "96M"
 php_apc_enable_cli: "0"
+
+# ODBC settings.
+php_odbc_default_db: "databasename"
+php_odbc_default_user: "username"
+php_odbc_default_pw: "password"
 
 # If this is set to false, none of the following options will have any effect.
 # Any and all changes to /etc/php.ini will be your responsibility.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,8 @@ php_allow_url_fopen: "On"
 
 php_sendmail_path: "/usr/sbin/sendmail -t -i"
 php_output_buffering: "4096"
+php_precision: 14
+php_serialize_precision: 17
 php_short_open_tag: "Off"
 php_disable_functions: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,7 @@ php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 php_display_errors: "Off"
 php_display_startup_errors: "Off"
 
+php_include_path: "/usr/share/php"
 # Install PHP from source (instead of using a package manager) with these vars.
 php_install_from_source: false
 php_source_repo: "https://git.php.net/repository/php-src.git"

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -124,6 +124,9 @@ mail.add_x_header = On
 sql.safe_mode = Off
 
 [ODBC]
+odbc.default_db    =  {{ php_odbc_default_db }}
+odbc.default_user  =  {{ php_odbc_default_user }}
+odbc.default_pw    =  {{ php_odbc_default_pw }}
 odbc.allow_persistent = On
 odbc.check_persistent = On
 odbc.max_persistent = -1

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -7,14 +7,14 @@
 engine = On
 short_open_tag = {{ php_short_open_tag }}
 asp_tags = Off
-precision = 14
+precision = {{ php_precision }}
 output_buffering = {{ php_output_buffering }}
 
 zlib.output_compression = Off
 
 implicit_flush = Off
 unserialize_callback_func =
-serialize_precision = 17
+serialize_precision = {{ php_serialize_precision }}
 disable_functions = {{ php_disable_functions|join(",") }}
 disable_classes =
 

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -77,6 +77,8 @@ enable_dl = Off
 
 realpath_cache_size = {{ php_realpath_cache_size }}
 
+include_path = {{ php_include_path }}
+
 ;;;;;;;;;;;;;;;;
 ; File Uploads ;
 ;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This is needed so we can override precision and serialize_precision values on a few json_encode values. 