### PR TITLE
Parameterize php-fpm log value

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you're using Apache, you can easily get it configured to work with PHP-FPM us
 
     php_fpm_listen: "127.0.0.1:9000"
     php_fpm_listen_allowed_clients: "127.0.0.1"
+    php_fpm_log_path: "syslog"
     php_fpm_pm_max_children: 50
     php_fpm_pm_start_servers: 5
     php_fpm_pm_min_spare_servers: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ php_enable_webserver: true
 php_enable_php_fpm: false
 php_fpm_listen: "127.0.0.1:9000"
 php_fpm_listen_allowed_clients: "127.0.0.1"
+php_fpm_log_path: "/var/log/php-fpm.log"
 php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -9,4 +9,4 @@ include={{ php_fpm_conf_path }}/pool.d/*.conf
 ;;;;;;;;;;;;;;;;;;
 
 [global]
-error_log = /var/log/php-fpm.log
+error_log = {{ php_fpm_log_path }}


### PR DESCRIPTION
Allow setting alternative paths to `php-fpm`'s `error_log`.