### PR TITLE
Fix php_fpm_pool_conf_path defitions and usage

### DIFF
--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -36,7 +36,7 @@
 - name: Ensure the default pool exists.
   template:
     src: www.conf.j2
-    dest: "{{ php_fpm_pool_conf_path }}"
+    dest: "{{ php_fpm_pool_conf_path }}/www.conf"
     owner: root
     group: root
     mode: 0644
@@ -45,7 +45,7 @@
 
 - name: Configure php-fpm pool (if enabled).
   lineinfile:
-    dest: "{{ php_fpm_pool_conf_path }}"
+    dest: "{{ php_fpm_pool_conf_path }}/www.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -2,7 +2,7 @@
 ; FPM Configuration ;
 ;;;;;;;;;;;;;;;;;;;;;
 
-include={{ php_fpm_conf_path }}/pool.d/*.conf
+include={{ php_fpm_pool_conf_path }}/*.conf
 
 ;;;;;;;;;;;;;;;;;;
 ; Global Options ;

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -31,7 +31,7 @@ __php_apc_conf_filename: 20-apcu.ini
 __php_opcache_conf_filename: 10-opcache.ini
 __php_fpm_daemon: php7.0-fpm
 __php_fpm_conf_path: "/etc/php/7.0/fpm"
-__php_fpm_pool_conf_path: "{{ __php_fpm_conf_path }}/pool.d/www.conf"
+__php_fpm_pool_conf_path: "{{ __php_fpm_conf_path }}/pool.d"
 
 __php_fpm_pool_user: www-data
 __php_fpm_pool_group: www-data

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -27,7 +27,7 @@ __php_apc_conf_filename: 50-apc.ini
 __php_opcache_conf_filename: 10-opcache.ini
 __php_fpm_daemon: php-fpm
 __php_fpm_conf_path: "/etc/fpm"
-__php_fpm_pool_conf_path: "/etc/php-fpm.d/www.conf"
+__php_fpm_pool_conf_path: "/etc/php-fpm.d"
 
 __php_fpm_pool_user: apache
 __php_fpm_pool_group: apache


### PR DESCRIPTION
Actually, __php_fpm_pool_conf_path point to a file by default and is not used by the php-fpm.conf.j2 template.

This fix intend to correct this and use the __php_fpm_pool_conf_path variable for what it was designed originally.