### PR TITLE
parameterize session.serialize_handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_display_startup_errors: "On"
     php_expose_php: "On"
     php_session_cookie_lifetime: 0
+    php_session_serialize_handler: php
     php_session_gc_probability: 1
     php_session_gc_divisor: 1000
     php_session_gc_maxlifetime: 1440

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,7 @@ php_short_open_tag: "Off"
 php_disable_functions: []
 
 php_session_cookie_lifetime: 0
+php_session_serialize_handler: php
 php_session_gc_probability: 1
 php_session_gc_divisor: 1000
 php_session_gc_maxlifetime: 1440

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -183,7 +183,7 @@ session.cookie_path = /
 session.cookie_domain =
 session.cookie_httponly =
 
-session.serialize_handler = php
+session.serialize_handler = {{ php_session_serialize_handler }}
 
 session.gc_probability = {{ php_session_gc_probability }}
 session.gc_divisor = {{ php_session_gc_divisor }}


### PR DESCRIPTION
Any update on https://github.com/geerlingguy/ansible-role-php/pull/210 and/or changes similar to https://github.com/geerlingguy/ansible-role-nginx#overriding-configuration-templates ?

In the meantime adding support to modify `serialize_handler`.