### PR TITLE
Added listen variables to php-fpm www.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you're using Apache, you can easily get it configured to work with PHP-FPM us
 
 Specific settings inside the default `www.conf` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template or using `lineinfile` like this role does inside `tasks/configure-fpm.yml`.
 
-Listen owner, group and mode are set as default. Do override for your usecase.
+Listen owner, group and mode are set as default. Do override them for your usecase.
 
 ### php.ini settings
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,13 @@ If you're using Apache, you can easily get it configured to work with PHP-FPM us
     php_fpm_pm_start_servers: 5
     php_fpm_pm_min_spare_servers: 5
     php_fpm_pm_max_spare_servers: 5
+    php_fpm_listen_owner: "www-data"
+    php_fpm_listen_group: "www-data"
+    php_fpm_listen_mode: "0660"
 
 Specific settings inside the default `www.conf` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template or using `lineinfile` like this role does inside `tasks/configure-fpm.yml`.
+
+Listen owner, group and mode are set as default. Do override for your usecase.
 
 ### php.ini settings
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,9 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
-php_fpm_listen_owner: "www-data"
-php_fpm_listen_group: "www-data"
-php_fpm_listen_mode: "0660"
+php_fpm_listen_owner: "{{ php_fpm_pool_user }}"
+php_fpm_listen_group: "{{ php_fpm_pool_group }}"
+php_fpm_listen_mode: "0600"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,9 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+php_fpm_listen_owner: "www-data"
+php_fpm_listen_group: "www-data"
+php_fpm_listen_mode: "0660"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -66,6 +66,12 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
+    - regexp: "^listen.owner.?=.+$"
+      line: "listen.owner = {{ php_fpm_listen_owner }}"
+    - regexp: "^listen.group.?=.+$"
+      line: "listen.group = {{ php_fpm_listen_group }}"
+    - regexp: "^listen.mode.?=.+$"
+      line: "listen.mode = {{ php_fpm_listen_mode }}"
   when: php_enable_php_fpm
   notify: restart php-fpm
 

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -66,11 +66,11 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-    - regexp: "^;?listen\.owner.?=.+$"
+    - regexp: '^;?listen\.owner.?=.+$'
       line: "listen.owner = {{ php_fpm_listen_owner }}"
-    - regexp: "^;?listen\.group.?=.+$"
+    - regexp: '^;?listen\.group.?=.+$'
       line: "listen.group = {{ php_fpm_listen_group }}"
-    - regexp: "^;?listen\.mode.?=.+$"
+    - regexp: '^;?listen\.mode.?=.+$'
       line: "listen.mode = {{ php_fpm_listen_mode }}"
   when: php_enable_php_fpm
   notify: restart php-fpm

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -66,9 +66,9 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-    - regexp: "^listen.owner.?=.+$"
+    - regexp: "^;?listen\.owner.?=?.*$"
       line: "listen.owner = {{ php_fpm_listen_owner }}"
-    - regexp: "^listen.group.?=.+$"
+    - regexp: "^;?listen\.group.?=?.*$"
       line: "listen.group = {{ php_fpm_listen_group }}"
     - regexp: "^listen.mode.?=.+$"
       line: "listen.mode = {{ php_fpm_listen_mode }}"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -66,11 +66,11 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-    - regexp: "^;?listen\.owner.?=?.*$"
+    - regexp: "^;?listen\.owner.?=.+$"
       line: "listen.owner = {{ php_fpm_listen_owner }}"
-    - regexp: "^;?listen\.group.?=?.*$"
+    - regexp: "^;?listen\.group.?=.+$"
       line: "listen.group = {{ php_fpm_listen_group }}"
-    - regexp: "^listen.mode.?=.+$"
+    - regexp: "^;?listen\.mode.?=.+$"
       line: "listen.mode = {{ php_fpm_listen_mode }}"
   when: php_enable_php_fpm
   notify: restart php-fpm


### PR DESCRIPTION
Listen variables were needed to correctly set permissions and ownership of php-fpm socket.
This is how I solved it, also added them to README and to default variables in order to pass the build.