### PR TITLE
fixing building from source on centos

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -1,7 +1,41 @@
 ---
-- name: Ensure dependencies for building from source are installed (RedHat).
+- name: Ensure dependencies for building from source are installed (CentOS).
+  package:
+    name: epel-release
+    state: present
+  when: ansible_distribution == "CentOS"
+  
+- name: Ensure dependencies for building from source are installed (RedHat < 7).
   package: "name={{ item }} state=present"
   with_items:
+    - git
+    - autoconf
+    - automake
+    - libtool
+    - bison
+    - make
+    - curl-devel
+    - recode-devel
+    - aspell-devel
+    - libxml2-devel
+    - pkgconfig
+    - libmcrypt-devel
+    - t1lib-devel
+    - libXpm-devel
+    - libpng-devel
+    - libjpeg-turbo-devel
+    - bzip2-devel
+    - openssl-devel
+    - freetype-devel
+    - libicu-devel
+    - mysql-devel
+    - gmp-devel
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version < "7"  
+
+- name: Ensure dependencies for building from source are installed (RedHat >= 7).
+  package: "name={{ item }} state=present"
+  with_items:
+    - git
     - autoconf
     - automake
     - libtool
@@ -23,7 +57,7 @@
     - libicu-devel
     - mariadb-devel
     - gmp-devel
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version >= "7"
 
 - name: Update apt cache (Debian).
   apt: update_cache=yes cache_valid_time=86400

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Ensure dependencies for building from source are installed (CentOS).
   package:
     name: epel-release


### PR DESCRIPTION
fix for:
fails to run when installing from source:
on centos 7.5/7.4/7.2/6.9 :
failed: [phptest] (item=libmcrypt-devel) => {"changed": false, "item": "libmcrypt-devel", "msg": "No package matching 'libmcrypt-devel' found available, installed or updated", "rc": 126, "results": ["No package matching 'libmcrypt-devel' found available, installed or updated"]}

fatal: [phptest]: FAILED! => {"changed": false, "msg": "Failed to find required executable git in paths: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin"}


on centos 6.9:
failed: [phpmemcachedtest] (item=mariadb-devel) => {"changed": false, "item": "mariadb-devel", "msg": "No package matching 'mariadb-devel' found available, installed or updated", "rc": 126, "results": ["No package matching 'mariadb-devel' found available, installed or updated"]}