### PR TITLE
Allow specification of fpm domain socket user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,10 @@ php_enable_webserver: true
 php_enable_php_fpm: false
 php_fpm_listen: "127.0.0.1:9000"
 php_fpm_listen_allowed_clients: "127.0.0.1"
+# php_fpm_listen_* only applicable when php_fpm_listen is running under a Unix
+# domain socket
+php_fpm_listen_owner: www-data
+php_fpm_listen_group: www-data
 php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -56,6 +56,12 @@
       line: "group = {{ php_fpm_pool_group }}"
     - regexp: "^listen.?=.+$"
       line: "listen = {{ php_fpm_listen }}"
+    - regexp: "^listen.owner.?=.+$"
+      line: "listen.owner = {{ php_fpm_listen_owner }}"
+      when: "{{ php_fpm_listen_owner is defined and php_fpm_listen_owner }}"
+    - regexp: "^listen.group.?=.+$"
+      line: "listen.group = {{ php_fpm_listen_group }}"
+      when: "{{ php_fpm_listen_group is defined and php_fpm_listen_group }}"
     - regexp: '^listen\.allowed_clients.?=.+$'
       line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
     - regexp: '^pm\.max_children.?=.+$'
@@ -66,7 +72,7 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-  when: php_enable_php_fpm
+  when: php_enable_php_fpm and item.when|default(True)
   notify: restart php-fpm
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).


### PR DESCRIPTION
When an fpm pool is bound to a Unix domain socket, it may be necessary
to adjust the default owner and/or group of that socket's inode in the
file system to ensure processes depending on the socket can connect.