### PR TITLE
Remove settings which are absent in php 7.0+

### DIFF
--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -6,7 +6,6 @@
 
 engine = On
 short_open_tag = {{ php_short_open_tag }}
-asp_tags = Off
 precision = 14
 output_buffering = {{ php_output_buffering }}
 
@@ -64,7 +63,6 @@ auto_prepend_file =
 auto_append_file =
 
 default_mimetype = "text/html"
-always_populate_raw_post_data = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Paths and Directories ;
@@ -189,8 +187,6 @@ session.gc_probability = {{ php_session_gc_probability }}
 session.gc_divisor = {{ php_session_gc_divisor }}
 session.gc_maxlifetime = {{ php_session_gc_maxlifetime }}
 
-session.bug_compat_42 = Off
-session.bug_compat_warn = Off
 session.referer_check =
 
 session.cache_limiter = nocache


### PR DESCRIPTION
https://www.php.net/manual/en/ini.core.php#ini.asp-tags
https://www.php.net/manual/en/ini.core.php#ini.always-populate-raw-post-data
https://www.php.net/manual/en/session.configuration.php#ini.session.bug-compat-42
https://www.php.net/manual/en/session.configuration.php#ini.session.bug-compat-warn

Removing them since this role/php only supports [7.1+](https://php.net/supported-versions.php)