### PR TITLE
Add the ability of enabling dynamic php extensions on managed php.ini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ By default, all the extra defaults below are applied through the php.ini include
 
 Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.
 
+    php_managed_ini_dynamic_extensions: ""
+When `php_use_managed_ini` is true, you can also use this variable to enable **previously installed** php dynamic extensions (see examples).
+
 ### OpCache-related Variables
 
 The OpCache is included in PHP starting in version 5.5, and the following variables will only take effect if the version of PHP you have installed is 5.5 or greater.
@@ -216,6 +219,9 @@ None.
       - php-pdo
       - php-pecl-apcu
       - php-xml
+    php_managed_ini_dynamic_extensions:
+      - name: MCrypt
+        extension: /usr/lib64/php/modules/mcrypt.so
       ...
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ php_apc_enable_cli: "0"
 # If this is set to false, none of the following options will have any effect.
 # Any and all changes to /etc/php.ini will be your responsibility.
 php_use_managed_ini: true
+php_managed_ini_dynamic_extensions: ""
 
 php_expose_php: "On"
 php_memory_limit: "256M"

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -223,3 +223,14 @@ soap.wsdl_cache_limit = 5
 
 [ldap]
 ldap.max_links = -1
+
+{% if php_managed_ini_dynamic_extensions is iterable and php_managed_ini_dynamic_extensions is not string %}
+;;;;;;;;;;;;;;;;;;;;;;
+; Dynamic Extensions ;
+;;;;;;;;;;;;;;;;;;;;;;
+{% for enabled_ext in php_managed_ini_dynamic_extensions %}
+[{{ enabled_ext['name'] }}]
+extension = {{ enabled_ext['extension'] }}
+
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This can be useful in scenarios where you are happy with the managed php ini this role provides but also you want to enable some dynamic extensions.