### PR TITLE
Allow configuring PHP error_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,17 @@ By default, all the extra defaults below are applied through the php.ini include
     php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
     php_display_errors: "Off"
     php_display_startup_errors: "On"
+    php_error_log: ""
+    php_error_log_owner: ""
+    php_error_log_group: ""
+    php_error_log_mode: 0644
     php_expose_php: "On"
     php_session_cookie_lifetime: 0
     php_session_gc_probability: 1
     php_session_gc_divisor: 1000
     php_session_gc_maxlifetime: 1440
     php_session_save_handler: files
-    php_session_save_path: ''
+    php_session_save_path: ""
     php_disable_functions: []
 
 Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,10 @@ php_session_save_path: ''
 php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 php_display_errors: "Off"
 php_display_startup_errors: "Off"
+php_error_log: ""
+php_error_log_owner: ""
+php_error_log_group: ""
+php_error_log_mode: 0644
 
 # Install PHP from source (instead of using a package manager) with these vars.
 php_install_from_source: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,3 +18,12 @@
   with_items: "{{ php_conf_paths }}"
   notify: restart webserver
   when: php_use_managed_ini
+
+- name: Create PHP error_log with appropriate permissions.
+  file:
+    path: "{{ php_error_log }}"
+    state: touch
+    owner: "{{ php_error_log_owner }}"
+    group: "{{ php_error_log_group }}"
+    mode: "{{ php_error_log_mode }}"
+  when: php_error_log and php_error_log != "syslog" and php_error_log_owner and php_error_log_group

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -42,6 +42,7 @@ memory_limit = {{ php_memory_limit }}
 error_reporting = {{ php_error_reporting }}
 display_errors = {{ php_display_errors }}
 display_startup_errors = {{ php_display_startup_errors }}
+error_log = {{ php_error_log }}
 log_errors = On
 log_errors_max_len = 1024
 ignore_repeated_errors = Off


### PR DESCRIPTION
Allow specifying `error_log` file in PHP.ini and configuring the owner/group/permissions of the file. An empty file is created if one doesn't exist. This should be mostly harmless, since it defaults to not being set, as it is currently. 

I'm not sure how common it is to configure `error_log`, or if most setups just use the PHP-FPM/Apache log. I prefer the cleaner PHP error log during development. 