### PR TITLE
Use |bool filter on opcache variable to avoid deprecation warning

### DIFF
--- a/tasks/configure-opcache.yml
+++ b/tasks/configure-opcache.yml
@@ -25,7 +25,7 @@
     force: true
     mode: 0644
   with_items: "{{ php_extension_conf_paths }}"
-  when: php_opcache_enable
+  when: php_opcache_enable|bool
   notify: restart webserver
 
 - name: Remove OpCache config file if OpCache is disabled.
@@ -33,5 +33,5 @@
     path: "{{ item }}/{{ php_opcache_conf_filename }}"
     state: absent
   with_items: "{{ php_extension_conf_paths }}"
-  when: not php_opcache_enable
+  when: not php_opcache_enable|bool
   notify: restart webserver

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -23,5 +23,5 @@
     path: "{{ item }}/{{ php_opcache_conf_filename }}"
     state: absent
   with_items: "{{ php_extension_conf_paths }}"
-  when: php_opcache_enable and php_package_install.changed
+  when: php_opcache_enable|bool and php_package_install.changed
   notify: restart webserver


### PR DESCRIPTION
When running the role, I'm getting a deprecation warning:

```
TASK [geerlingguy.php : Ensure OpCache config file is present.] ****************************************************************************************
[DEPRECATION WARNING]: evaluating 1 as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future.
Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This fixes by using the `bool` filter to convert the variable to a boolean for conditional checks.