### PR TITLE
Add OPCache variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ The OpCache is included in PHP starting in version 5.5, and the following variab
     php_opcache_revalidate_path: "0"
     php_opcache_revalidate_freq: "2"
     php_opcache_max_file_size: "0"
+    php_opcache_blacklist_filename: ""
+    php_opcache_consistency_checks: ""
+    php_opcache_save_comments: ""
+    php_opcache_fast_shutdown: ""
 
 OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_consistency_checks: ""
+php_opcache_save_comments: ""
+php_opcache_fast_shutdown: ""
 
 # APCu settings.
 php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -12,3 +12,12 @@ opcache.max_file_size={{ php_opcache_max_file_size }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}
+{% if php_opcache_consistency_checks != '' %}
+opcache.consistency_checks={{ php_opcache_consistency_checks }}
+{% endif %}
+{% if php_opcache_save_comments != '' %}
+opcache.save_comments={{ php_opcache_save_comments }}
+{% endif %}
+{% if php_opcache_fast_shutdown != '' %}
+opcache.fast_shutdown={{ php_opcache_fast_shutdown }}
+{% endif %}


### PR DESCRIPTION
This PR adds the following OPCache variables: 
- php_opcache_consistency_checks
- php_opcache_save_comments:
- php_opcache_fast_shutdown

Signed-off-by: Guillaume de Lafond <13253032+gdelafond@users.noreply.github.com>