### PR TITLE
Removing php-imap from RedHat vars

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,7 +6,6 @@ __php_packages:
   - php-devel
   - php-fpm
   - php-gd
-  - php-imap
   - php-ldap
   - php-mbstring
   - php-opcache


### PR DESCRIPTION
php-imap is not available anymore.. it was epel7 and will not be included in rh8