### PR TITLE
Allow php_opcache to have any number of extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,23 +122,28 @@ Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.
 
 The OpCache is included in PHP starting in version 5.5, and the following variables will only take effect if the version of PHP you have installed is 5.5 or greater.
 
-    php_opcache_zend_extension: "opcache.so"
-    php_opcache_enable: "1"
-    php_opcache_enable_cli: "0"
-    php_opcache_memory_consumption: "96"
-    php_opcache_interned_strings_buffer: "16"
-    php_opcache_max_accelerated_files: "4096"
-    php_opcache_max_wasted_percentage: "5"
-    php_opcache_validate_timestamps: "1"
-    php_opcache_revalidate_path: "0"
-    php_opcache_revalidate_freq: "2"
-    php_opcache_max_file_size: "0"
+    php_opcache:
+        zend_extension: "opcache.so"
+        enable: "1"
+        enable_cli: "0"
+        memory_consumption: "96"
+        interned_strings_buffer: "16"
+        max_accelerated_files: "4096"
+        max_wasted_percentage: "5"
+        validate_timestamps: "1"
+        revalidate_path: "0"
+        revalidate_freq: "2"
+        max_file_size: "0"
 
-OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
+OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache.memory_consumption`, in MB, and `php_opcache.max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
 
-For custom opcache.so location provide full path with `php_opcache_zend_extension`.
+**Note:**
 
-    php_opcache_conf_filename: [platform-specific]
+If you intend to redefine a value of the php_opcache, just define the php_opcache value in your vars. The defaults values are set by the php_opcache_defaults in the main.yml file. 
+
+For custom opcache.so location provide full path with `php_opcache.zend_extension`.
+
+    php_opcache.conf_filename: [platform-specific]
 
 The platform-specific opcache configuration filename. Generally the default should work, but in some cases, you may need to override the filename.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,19 +34,20 @@ php_fpm_pm_max_spare_servers: 5
 # The executable to run when calling PHP from the command line.
 php_executable: "php"
 
-# OpCache settings.
-php_opcache_zend_extension: "opcache.so"
-php_opcache_enable: "1"
-php_opcache_enable_cli: "0"
-php_opcache_memory_consumption: "96"
-php_opcache_interned_strings_buffer: "16"
-php_opcache_max_accelerated_files: "4096"
-php_opcache_max_wasted_percentage: "5"
-php_opcache_validate_timestamps: "1"
-php_opcache_revalidate_path: "0"
-php_opcache_revalidate_freq: "2"
-php_opcache_max_file_size: "0"
-php_opcache_blacklist_filename: ""
+# OpCache default settings.
+php_opcache_defaults:
+  zend_extension: "opcache.so"
+  enable: "1"
+  enable_cli: "0"
+  memory_consumption: "96"
+  interned_strings_buffer: "16"
+  max_accelerated_files: "4096"
+  max_wasted_percentage: "5"
+  validate_timestamps: "1"
+  revalidate_path: "0"
+  revalidate_freq: "2"
+  max_file_size: "0"
+  blacklist_filename: ""
 
 # APCu settings.
 php_enable_apc: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,8 @@
     php_memory_limit: "192M"
     php_enablerepo: "remi,remi-php70"
     php_install_recommends: false
+    php_opcache:
+      memory_consumption: "128"
 
   handlers:
     - name: update apt cache
@@ -67,4 +69,12 @@
   post_tasks:
     - name: Confirm PHP configuration is correct.
       shell: php -i | grep 'memory_limit.*192'
+      changed_when: false
+
+    - name: Confirm PHP opcache default configuration is correct.
+      shell: php -i | grep 'opcache.max_accelerated_files.*4096'
+      changed_when: false
+
+    - name: Confirm PHP opcache configuration set in playbook is correct.
+      shell: php -i | grep 'opcache.memory_consumption.*128'
       changed_when: false

--- a/tasks/configure-opcache.yml
+++ b/tasks/configure-opcache.yml
@@ -10,7 +10,7 @@
   file:
     path: "{{ item.1.path }}"
     state: absent
-  when: php_opcache_conf_filename != (item.1.path.split('/') | last)
+  when: php_opcache.conf_filename != (item.1.path.split('/') | last)
   with_subelements:
     - "{{ php_installed_opcache_confs.results }}"
     - files
@@ -19,19 +19,19 @@
 - name: Ensure OpCache config file is present.
   template:
     src: opcache.ini.j2
-    dest: "{{ item }}/{{ php_opcache_conf_filename }}"
+    dest: "{{ item }}/{{ php_opcache.conf_filename }}"
     owner: root
     group: root
     force: true
     mode: 0644
   with_items: "{{ php_extension_conf_paths }}"
-  when: php_opcache_enable | bool
+  when: php_opcache.enable | bool
   notify: restart webserver
 
 - name: Remove OpCache config file if OpCache is disabled.
   file:
-    path: "{{ item }}/{{ php_opcache_conf_filename }}"
+    path: "{{ item }}/{{ php_opcache.conf_filename }}"
     state: absent
   with_items: "{{ php_extension_conf_paths }}"
-  when: not php_opcache_enable | bool
+  when: not php_opcache.enable | bool
   notify: restart webserver

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,15 +39,25 @@
     php_apc_conf_filename: "{{ __php_apc_conf_filename }}"
   when: php_apc_conf_filename is not defined
 
-- name: Define php_opcache_conf_filename (Ubuntu 16.04).
-  set_fact:
-    php_opcache_conf_filename: "10-opcache.ini"
-  when: php_opcache_conf_filename is not defined and ansible_distribution_version == "16.04"
+- name: Define defaults for php opcache (from php_opcache_defaults)
+  block:
+    - name: Set php_opcache if not defined
+      set_fact:
+        php_opcache: {}
+      when: php_opcache is not defined
+    - name: Combine php_opcache defaults and current setting values
+      set_fact:
+        php_opcache: "{{ php_opcache_defaults | combine(php_opcache) }}"
 
-- name: Define php_opcache_conf_filename.
+- name: Define php_opcache.conf_filename (Ubuntu 16.04).
   set_fact:
-    php_opcache_conf_filename: "{{ __php_opcache_conf_filename }}"
-  when: php_opcache_conf_filename is not defined
+    php_opcache: "{{ php_opcache | combine({ 'conf_filename': '10-opcache.ini'}) }}"
+  when: php_opcache.conf_filename is not defined and ansible_distribution_version == "16.04"
+
+- name: Define php_opcache.conf_filename.
+  set_fact:
+    php_opcache: "{{ php_opcache | combine({ 'conf_filename': __php_opcache.conf_filename }) }}"
+  when: php_opcache.conf_filename is not defined
 
 - name: Define php_fpm_conf_path.
   set_fact:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -20,8 +20,8 @@
 
 - name: Delete OpCache configuration file if this role will provide one.
   file:
-    path: "{{ item }}/{{ php_opcache_conf_filename }}"
+    path: "{{ item }}/{{ php_opcache.conf_filename }}"
     state: absent
   with_items: "{{ php_extension_conf_paths }}"
-  when: php_opcache_enable | bool and php_package_install.changed
+  when: php_opcache.enable and php_package_install.changed
   notify: restart webserver

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -1,14 +1,6 @@
-zend_extension={{ php_opcache_zend_extension }}
-opcache.enable={{ php_opcache_enable }}
-opcache.enable_cli={{ php_opcache_enable_cli }}
-opcache.memory_consumption={{ php_opcache_memory_consumption }}
-opcache.interned_strings_buffer={{ php_opcache_interned_strings_buffer }}
-opcache.max_accelerated_files={{ php_opcache_max_accelerated_files }}
-opcache.max_wasted_percentage={{ php_opcache_max_wasted_percentage }}
-opcache.validate_timestamps={{ php_opcache_validate_timestamps }}
-opcache.revalidate_path={{ php_opcache_revalidate_path }}
-opcache.revalidate_freq={{ php_opcache_revalidate_freq }}
-opcache.max_file_size={{ php_opcache_max_file_size }}
-{% if php_opcache_blacklist_filename != '' %}
-opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
+zend_extension={{ php_opcache.zend_extension }}
+{% for key, value in php_opcache.items() %}
+{% if value != '' and key != 'conf_filename' and 'key' != 'zend_extension' %}
+opcache.{{key}}={{ value }}
 {% endif %}
+{% endfor %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -30,7 +30,9 @@ __php_extension_conf_paths:
   - /etc/php/{{ php_default_version_debian }}/cli/conf.d
 
 __php_apc_conf_filename: 20-apcu.ini
-__php_opcache_conf_filename: 10-opcache.ini
+__php_opcache:
+  conf_filename: 10-opcache.ini
+
 __php_fpm_daemon: php{{ php_default_version_debian }}-fpm
 __php_fpm_conf_path: "/etc/php/{{ php_default_version_debian }}/fpm"
 __php_fpm_pool_conf_path: "{{ __php_fpm_conf_path }}/pool.d/www.conf"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -23,7 +23,9 @@ __php_extension_conf_paths:
   - /etc/php.d
 
 __php_apc_conf_filename: 50-apc.ini
-__php_opcache_conf_filename: 10-opcache.ini
+__php_opcache:
+  conf_filename: 10-opcache.ini
+
 __php_fpm_daemon: php-fpm
 __php_fpm_conf_path: "/etc/fpm"
 __php_fpm_pool_conf_path: "/etc/php-fpm.d/www.conf"


### PR DESCRIPTION
Aim of this patch is to allow other configuration values to be added to opcache without having to change the base php role values (https://www.php.net/manual/fr/opcache.configuration.php)

- Use a dictionary instead of a fixed set of variables
- Add the default php_opcache_defaults values
- Ensure we have a default value for php_opcache dictionary