### PR TITLE
Make serialize_precision a parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ php_output_buffering: "4096"
 php_short_open_tag: "Off"
 php_disable_functions: []
 php_precision: 14
+php_serialize_precision: "-1"
 
 php_session_cookie_lifetime: 0
 php_session_gc_probability: 1

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -13,7 +13,7 @@ zlib.output_compression = Off
 
 implicit_flush = Off
 unserialize_callback_func =
-serialize_precision = 17
+serialize_precision = {{ php_serialize_precision }}
 disable_functions = {{ php_disable_functions|join(",") }}
 disable_classes =
 


### PR DESCRIPTION
According to the php documentation, the default version for php should be "-1". Before php7.1 it was 17, so I parameterized it, and made the default "-1"

see https://www.php.net/manual/en/ini.list.php