### PR TITLE
Allow user to manage the www.conf file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 
 php_fpm_pool_conf_template: "www.conf.j2"
-php_fpm_use_managed_ini: true
+php_fpm_use_managed_conf: true
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 
+php_fpm_pool_conf_template: "www.conf.j2"
+php_fpm_use_managed_ini: true
+
 # The executable to run when calling PHP from the command line.
 php_executable: "php"
 

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -33,15 +33,17 @@
     mode: 0755
   when: php_fpm_pool_conf_path_dir_stat.stat.islnk is not defined
 
-- name: Ensure the default pool exists.
+- name: Manage the php-fpm www pool
   template:
-    src: www.conf.j2
+    src: "{{ php_fpm_pool_conf_template }}"
     dest: "{{ php_fpm_pool_conf_path }}"
     owner: root
     group: root
     mode: 0644
-    force: false
-  when: php_enable_php_fpm
+  when:
+    - php_enable_php_fpm
+    - not php_fpm_use_managed_ini
+  notify: restart php-fpm
 
 - name: Configure php-fpm pool (if enabled).
   lineinfile:
@@ -66,7 +68,9 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-  when: php_enable_php_fpm
+  when:
+    - php_enable_php_fpm
+    - php_fpm_use_managed_ini
   notify: restart php-fpm
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -42,7 +42,7 @@
     mode: 0644
   when:
     - php_enable_php_fpm
-    - not php_fpm_use_managed_ini
+    - not php_fpm_use_managed_conf
   notify: restart php-fpm
 
 - name: Configure php-fpm pool (if enabled).
@@ -70,7 +70,7 @@
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
   when:
     - php_enable_php_fpm
-    - php_fpm_use_managed_ini
+    - php_fpm_use_managed_conf
   notify: restart php-fpm
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).


### PR DESCRIPTION
Allows the user to manage the www.conf php-fpm file via a template. 

I've added two variables:

* php_fpm_pool_conf_template: Allows the user to specify their own template file
* php_fpm_use_managed_conf: maintains the default behavior of the role to manage the www.conf file with the lineinfile module