### PR TITLE
Added possibility to choose if php-fpm is restarted or reloaded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ If you're using Apache, you can easily get it configured to work with PHP-FPM us
 
 Control over the fpm daemon's state; set these to `stopped` and `false` if you want FPM to be installed and configured, but not running (e.g. when installing in a container).
 
+    php_fpm_handler_state: restarted
+
+The handler restarts PHP-FPM by default. Setting the value to `reloaded` will reload the service, intead of restarting it.
+
     php_fpm_listen: "127.0.0.1:9000"
     php_fpm_listen_allowed_clients: "127.0.0.1"
     php_fpm_pm_max_children: 50

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ php_enable_webserver: true
 # PHP-FPM configuration.
 php_enable_php_fpm: false
 php_fpm_state: started
+php_fpm_handler_state: restarted
 php_fpm_enabled_on_boot: true
 php_fpm_listen: "127.0.0.1:9000"
 php_fpm_listen_allowed_clients: "127.0.0.1"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,7 +9,7 @@
 - name: restart php-fpm
   service:
     name: "{{ php_fpm_daemon }}"
-    state: restarted
+    state: "{{ php_fpm_handler_state }}"
   when:
     - php_enable_php_fpm
     - php_fpm_state == 'started'


### PR DESCRIPTION
In production systems, it is sometimes better to reload FPM instead of
restarting. This commit allows users to manage restart or reload of php-fpm
service, but keeps restarting by default.

Co-authored-by: Julien LE SAUX <julien.le.saux@fr.clara.net>