### PR TITLE
Add preload and preload_user variables(optional) to opcache config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,9 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_preload: ""
+php_opcache_preload_user: ""
+
 
 # APCu settings.
 php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -12,3 +12,9 @@ opcache.max_file_size={{ php_opcache_max_file_size }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}
+{% if php_opcache_preload != '' %}
+opcache.preload={{ php_opcache_preload }}
+{% endif %}
+{% if php_opcache_preload_user != '' %}
+opcache.preload_user={{ php_opcache_preload_user }}
+{% endif %}


### PR DESCRIPTION
Since the PHP7.4 release date(November 28, 2019) [preloading](https://wiki.php.net/rfc/preload) can be enabled. It can carry significant performance improvements just by adding two new variables to opcache config.