### PR TITLE
Configure extra fpm pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,24 @@ Control over the fpm daemon's state; set these to `stopped` and `false` if you w
 
 The handler restarts PHP-FPM by default. Setting the value to `reloaded` will reload the service, intead of restarting it.
 
-    php_fpm_listen: "127.0.0.1:9000"
-    php_fpm_listen_allowed_clients: "127.0.0.1"
-    php_fpm_pm_max_children: 50
-    php_fpm_pm_start_servers: 5
-    php_fpm_pm_min_spare_servers: 5
-    php_fpm_pm_max_spare_servers: 5
+    php_fpm_pools
 
-Specific settings inside the default `www.conf` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template or using `lineinfile` like this role does inside `tasks/configure-fpm.yml`.
+List of PHP-FPM pool to create. By default, www pool is created.
+
+    pool_name: www
+    pool_template: www.conf.j2
+    pool_listen: "127.0.0.1:9000"
+    pool_listen_allowed_clients: "127.0.0.1"
+    pool_pm: dynamic
+    pool_pm_max_children: 50
+    pool_pm_start_servers: 5
+    pool_pm_min_spare_servers: 5
+    pool_pm_max_spare_servers: 5
+    pool_pm_max_requests: 500
+
+To setup a new pool, add an item to php_fpm_pools list.
+
+Specific settings inside the default `www.conf.j2` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template using `pool_template`.
 
 ### php.ini settings
 

--- a/README.md
+++ b/README.md
@@ -71,22 +71,20 @@ Control over the fpm daemon's state; set these to `stopped` and `false` if you w
 
 The handler restarts PHP-FPM by default. Setting the value to `reloaded` will reload the service, intead of restarting it.
 
-    php_fpm_pools
 
-List of PHP-FPM pool to create. By default, www pool is created.
+    php_fpm_pools:
+      - pool_name: www
+        pool_template: www.conf.j2
+        pool_listen: "127.0.0.1:9000"
+        pool_listen_allowed_clients: "127.0.0.1"
+        pool_pm: dynamic
+        pool_pm_max_children: 50
+        pool_pm_start_servers: 5
+        pool_pm_min_spare_servers: 5
+        pool_pm_max_spare_servers: 5
+        pool_pm_max_requests: 500
 
-    pool_name: www
-    pool_template: www.conf.j2
-    pool_listen: "127.0.0.1:9000"
-    pool_listen_allowed_clients: "127.0.0.1"
-    pool_pm: dynamic
-    pool_pm_max_children: 50
-    pool_pm_start_servers: 5
-    pool_pm_min_spare_servers: 5
-    pool_pm_max_spare_servers: 5
-    pool_pm_max_requests: 500
-
-To setup a new pool, add an item to php_fpm_pools list.
+List of PHP-FPM pool to create. By default, www pool is created. To setup a new pool, add an item to php_fpm_pools list.
 
 Specific settings inside the default `www.conf.j2` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template using `pool_template`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,16 +37,6 @@ php_fpm_pools:
     pool_pm_min_spare_servers: 5
     pool_pm_max_spare_servers: 5
     pool_pm_max_requests: 500
-#  - pool_name: pool
-#    pool_template: www.conf.j2
-#    pool_listen: 127.0.0.1:9001
-#    pool_listen_allowed_clients: 127.0.0.1
-#    pool_pm: dynamic
-#    pool_pm_max_children: 50
-#    pool_pm_start_servers: 5
-#    pool_pm_min_spare_servers: 5
-#    pool_pm_max_spare_servers: 5
-#    pool_pm_max_requests: 500
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,10 +32,10 @@ php_fpm_pools:
     pool_listen: "127.0.0.1:9000"
     pool_listen_allowed_clients: "127.0.0.1"
     pool_pm: dynamic
-    pool_pm_max_children: 50
-    pool_pm_start_servers: 5
-    pool_pm_min_spare_servers: 5
-    pool_pm_max_spare_servers: 5
+    pool_pm_max_children: 5
+    pool_pm_start_servers: 2
+    pool_pm_min_spare_servers: 1
+    pool_pm_max_spare_servers: 3
     pool_pm_max_requests: 500
 
 # The executable to run when calling PHP from the command line.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,12 +24,29 @@ php_enable_php_fpm: false
 php_fpm_state: started
 php_fpm_handler_state: restarted
 php_fpm_enabled_on_boot: true
-php_fpm_listen: "127.0.0.1:9000"
-php_fpm_listen_allowed_clients: "127.0.0.1"
-php_fpm_pm_max_children: 50
-php_fpm_pm_start_servers: 5
-php_fpm_pm_min_spare_servers: 5
-php_fpm_pm_max_spare_servers: 5
+
+# PHP-FPM pool configuration.
+php_fpm_pools:
+  - pool_name: www
+    pool_template: www.conf.j2
+    pool_listen: "127.0.0.1:9000"
+    pool_listen_allowed_clients: "127.0.0.1"
+    pool_pm: dynamic
+    pool_pm_max_children: 50
+    pool_pm_start_servers: 5
+    pool_pm_min_spare_servers: 5
+    pool_pm_max_spare_servers: 5
+    pool_pm_max_requests: 500
+#  - pool_name: pool
+#    pool_template: www.conf.j2
+#    pool_listen: 127.0.0.1:9001
+#    pool_listen_allowed_clients: 127.0.0.1
+#    pool_pm: dynamic
+#    pool_pm_max_children: 50
+#    pool_pm_start_servers: 5
+#    pool_pm_min_spare_servers: 5
+#    pool_pm_max_spare_servers: 5
+#    pool_pm_max_requests: 500
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -33,40 +33,15 @@
     mode: 0755
   when: php_fpm_pool_conf_path_dir_stat.stat.islnk is not defined
 
-- name: Ensure the default pool exists.
+- name: Create fpm pools.
   template:
-    src: www.conf.j2
-    dest: "{{ php_fpm_pool_conf_path }}"
+    src: "{{ item.pool_template | default('www.conf.j2', true) }}"
+    dest: "{{ php_fpm_pool_conf_path | dirname }}/{{ item.pool_name }}.conf"
     owner: root
     group: root
     mode: 0644
-    force: false
-  when: php_enable_php_fpm
-
-- name: Configure php-fpm pool (if enabled).
-  lineinfile:
-    dest: "{{ php_fpm_pool_conf_path }}"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-    state: present
-    mode: 0644
-  with_items:
-    - regexp: "^user.?=.+$"
-      line: "user = {{ php_fpm_pool_user }}"
-    - regexp: "^group.?=.+$"
-      line: "group = {{ php_fpm_pool_group }}"
-    - regexp: "^listen.?=.+$"
-      line: "listen = {{ php_fpm_listen }}"
-    - regexp: '^listen\.allowed_clients.?=.+$'
-      line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
-    - regexp: '^pm\.max_children.?=.+$'
-      line: "pm.max_children = {{ php_fpm_pm_max_children }}"
-    - regexp: '^pm\.start_servers.?=.+$'
-      line: "pm.start_servers = {{ php_fpm_pm_start_servers }}"
-    - regexp: '^pm\.min_spare_servers.?=.+$'
-      line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
-    - regexp: '^pm\.max_spare_servers.?=.+$'
-      line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
+    force: true
+  loop: "{{ php_fpm_pools | default([], true) }}"
   when: php_enable_php_fpm
   notify: restart php-fpm
 

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -1,15 +1,17 @@
-[www]
-listen = 127.0.0.1:9000
-listen.allowed_clients = 127.0.0.1
+; {{ ansible_managed }}
+
+[{{ item.pool_name | mandatory }}]
+listen = {{ item.pool_listen | mandatory }}
+listen.allowed_clients = {{ item.pool_listen_allowed_clients | default('127.0.0.1', true) }}
 user = {{ php_fpm_pool_user }}
 group = {{ php_fpm_pool_group }}
 
 listen.owner = {{ php_fpm_pool_user }}
 listen.group = {{ php_fpm_pool_group }}
 
-pm = dynamic
-pm.max_children = 50
-pm.start_servers = 5
-pm.min_spare_servers = 5
-pm.max_spare_servers = 5
-pm.max_requests = 500
+pm = {{ item.pool_pm | default('dynamic', true) }}
+pm.max_children = {{ item.pool_pm_max_children | default(50, true) }}
+pm.start_servers = {{ item.pool_pm_start_servers | default(5, true) }}
+pm.min_spare_servers = {{ item.pool_pm_min_spare_servers | default(5, true) }}
+pm.max_spare_servers = {{ item.pool_pm_max_spare_servers | default(5, true) }}
+pm.max_requests = {{ item.pool_pm_max_requests | default(500, true) }}


### PR DESCRIPTION
Allow to configure extra fpm pools with a generic template.

You can find an example of php_fpm_extra_pools usage in default vars.
pool_name and pool_listen are mandatory.