### PR TITLE
Add cookie_httponly and cookie_secure to managed php.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ By default, all the extra defaults below are applied through the php.ini include
     php_display_startup_errors: "On"
     php_expose_php: "On"
     php_session_cookie_lifetime: 0
+    php_session_cookie_httponly: "Off"
+    php_session_cookie_secure: "Off"
     php_session_gc_probability: 1
     php_session_gc_divisor: 1000
     php_session_gc_maxlifetime: 1440

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,6 +78,8 @@ php_disable_functions: []
 php_precision: 14
 
 php_session_cookie_lifetime: 0
+php_session_cookie_httponly: "Off"
+php_session_cookie_secure: "Off"
 php_session_gc_probability: 1
 php_session_gc_divisor: 1000
 php_session_gc_maxlifetime: 1440

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -179,7 +179,8 @@ session.auto_start = 0
 session.cookie_lifetime = {{ php_session_cookie_lifetime }}
 session.cookie_path = /
 session.cookie_domain =
-session.cookie_httponly =
+session.cookie_httponly = {{ php_session_cookie_httponly }}
+session.cookie_secure = {{ php_session_cookie_secure }}
 
 session.serialize_handler = php
 


### PR DESCRIPTION
These are two fairly important security options that should usually be set to true on a production website, so it seems like would make sense to add these to the managed php.ini file for convenience. Of course, I default to false here to maintain backwards compatibility. 