### PR TITLE
explicitly add listen.owner and listen.group options to www.conf

### DIFF
--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -56,6 +56,10 @@
       line: "group = {{ php_fpm_pool_group }}"
     - regexp: "^listen.?=.+$"
       line: "listen = {{ php_fpm_listen }}"
+    - regexp: '^listen\.owner.?=.+$'
+      line: "listen.owner = {{ php_fpm_pool_user }}"
+    - regexp: '^listen\.group.?=.+$'
+      line: "listen.group = {{ php_fpm_pool_group }}"
     - regexp: '^listen\.allowed_clients.?=.+$'
       line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
     - regexp: '^pm\.max_children.?=.+$'


### PR DESCRIPTION
Fixes the bug reported by me in the comment to [this issue](https://github.com/geerlingguy/ansible-role-php/issues/166#issuecomment-672276711)

Ubuntu 20.04.1 provides default `fpm/pool.d/www.conf` for PHP 7.4.

Thus, "Ensure the default pool exists" task in `tasks/configure-fpm.yml` does not create the file with correct `listen.owner` and `listen.group`. Both have to be specified in the "Configure php-fpm pool (if enabled)" task.
