### PR TITLE
Allow the php version to be overridden.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,11 @@
     - files:
         - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
       skip: true
+
 - name: Set the default PHP version for Debian-based OSes.
   set_fact:
     php_default_version_debian: "{{ __php_default_version_debian }}"
-  when: ansible_os_family == 'Debian'
+  when: php_default_version_debian is not defined and ansible_os_family == 'Debian'
 
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
I found out I was unable to specify 7.3 on an Ubuntu 18 installation, and it stemmed from a clean up that enforced the default version being configured on Debian based systems.