### PR TITLE
Fix php-fpm conf listen parameters

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,7 @@
     php_memory_limit: "192M"
     php_enablerepo: "remi,remi-php70"
     php_install_recommends: false
+    php_fpm_listen_allowed_clients: "any"
 
   handlers:
     - name: update apt cache
@@ -65,6 +66,9 @@
     - role: geerlingguy.php
 
   post_tasks:
-    - name: Confirm PHP configuration is correct.
+    - name: Confirm PHP configuration for memory limit is correct.
       shell: php -i | grep 'memory_limit.*192'
+      changed_when: false
+    - name: Confirm PHP configuration for allowed clients is correct.
+      shell: grep  'allowed_clients.*any' /etc/php-fpm.d/www.conf
       changed_when: false

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -57,8 +57,6 @@
       line: "group = {{ php_fpm_pool_group }}"
     - regexp: "^listen.?=.+$"
       line: "listen = {{ php_fpm_listen }}"
-    - regexp: '^listen\.allowed_clients.?=.+$'
-      line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
     - regexp: '^pm\.max_children.?=.+$'
       line: "pm.max_children = {{ php_fpm_pm_max_children }}"
     - regexp: '^pm\.start_servers.?=.+$'
@@ -69,6 +67,24 @@
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
   when: php_enable_php_fpm
   notify: restart php-fpm
+
+# This is a very special variable that if defined cannot get a default value
+# The documentation says 'any' would work but it does not. So if not specified
+# we just don't add it to the configuration so the php-fpm process can still
+# respond to any hosts
+- name: Configure php-fpm pool listen allowed clients (if enabled).
+  lineinfile:
+    dest: "{{ php_fpm_pool_conf_path }}"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: present
+    mode: 0644
+  with_items:
+    - regexp: '^listen\.allowed_clients.?=.+$'
+      line: "listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}"
+  when: php_enable_php_fpm and (php_fpm_listen_allowed_clients|length >0)
+  notify: restart php-fpm
+
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -1,6 +1,10 @@
 [www]
-listen = 127.0.0.1:9000
-listen.allowed_clients = 127.0.0.1
+listen = {{ php_fpm_listen }}
+
+{% if php_fpm_listen_allowed_clients.strip() %}
+listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}
+{% endif %}
+
 user = {{ php_fpm_pool_user }}
 group = {{ php_fpm_pool_group }}
 


### PR DESCRIPTION
The php_fpm_listen and php_fpm_listen_allowed_clients should be taken into account when writing the www.conf configuration file for FPM. They were hardcoded into the conf.

This patch makes sure that the php-fpm conf takes into account *allowed clients* and *listen* parameters provided in the role vars and add further molecule tests to validate the change.