### PR TITLE
Add php_fpm_clear_env parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The handler restarts PHP-FPM by default. Setting the value to `reloaded` will re
     php_fpm_pm_start_servers: 5
     php_fpm_pm_min_spare_servers: 5
     php_fpm_pm_max_spare_servers: 5
+    php_fpm_clear_env: true
 
 Specific settings inside the default `www.conf` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template or using `lineinfile` like this role does inside `tasks/configure-fpm.yml`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+php_fpm_clear_env: true
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -77,6 +77,8 @@
     line: "clear_env = {{ 'yes' if php_fpm_clear_env else 'no' }}"
     state: present
     mode: 0644
+  when: php_enable_php_fpm
+  notify: restart php-fpm
 
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -70,6 +70,14 @@
   when: php_enable_php_fpm
   notify: restart php-fpm
 
+- name: Configure fpm clear_env
+  lineinfile:
+    dest: "{{ php_fpm_pool_conf_path }}"
+    regexp: "clear_env\\s*=\\s*(yes|no)$"
+    line: "clear_env = {{ 'yes' if php_fpm_clear_env else 'no' }}"
+    state: present
+    mode: 0644
+
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:
     name: "{{ php_fpm_daemon }}"


### PR DESCRIPTION
Using the clear_env you can control if a FPM process will receive the
default environment variables[^1] such as the Path. For example nextcloud
requires / recommends the path variable for some operations[^2], therefore I
would assume this to be widely used enough to put it directly in the
core of the role.

[^1]: <https://www.php.net/manual/en/install.fpm.configuration.php#clear-env>
[^2]: <https://docs.nextcloud.com/server/19/admin_manual/installation/source_installation.html#php-fpm-configuration-notes>