### PR TITLE
Manage php-fpm.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ List of PHP-FPM pool to create. By default, www pool is created. To setup a new 
 
 Specific settings inside the default `www.conf.j2` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template using `pool_template`.
 
+FPM global options in `php-fpmd.conf` can be controlled by using `php_fpm_global_options`. The default is:
+
+    error_log = /var/log/php-fpm.log
+
 ### php.ini settings
 
     php_use_managed_ini: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 php_fpm_pm_max_requests: 0
+php_fpm_global_options: |
+  error_log = /var/log/php-fpm.log
 
 # PHP-FPM pool configuration.
 php_fpm_pools:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,11 +9,6 @@
     php_memory_limit: "192M"
     php_enablerepo: "remi,remi-php70"
     php_install_recommends: false
-    php_fpm_global_options: |
-      # if 10 children fail within a minute restart
-      emergency_restart_threshold = 10
-      emergency_restart_interval = 1m
-      process_control_timeout = 10s
 
   handlers:
     - name: update apt cache

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,11 @@
     php_memory_limit: "192M"
     php_enablerepo: "remi,remi-php70"
     php_install_recommends: false
+    php_fpm_global_options: |
+      # if 10 children fail within a minute restart
+      emergency_restart_threshold = 10
+      emergency_restart_interval = 1m
+      process_control_timeout = 10s
 
   handlers:
     - name: update apt cache

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -45,6 +45,19 @@
   when: php_enable_php_fpm
   notify: restart php-fpm
 
+- name: Ensure php-fpm config directory exists.
+  file:
+    path: "{{ php_fpm_conf_path }}"
+    state: directory
+    mode: 0755
+
+- name: Ensure php-fpm config file is installed.
+  template:
+    src: php-fpm.conf.j2
+    dest: "{{ php_fpm_conf_path }}/php-fpm.conf"
+    mode: 0644
+  notify: restart php-fpm
+
 - name: Ensure php-fpm is started and enabled at boot (if configured).
   service:
     name: "{{ php_fpm_daemon }}"

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -142,17 +142,4 @@
   when: "'--enable-fpm' in php_source_configure_command"
   notify: restart php-fpm
 
-- name: Ensure php-fpm config directory exists.
-  file:
-    path: "{{ php_fpm_conf_path }}"
-    state: directory
-    mode: 0755
-  when: "'--enable-fpm' in php_source_configure_command"
 
-- name: Ensure php-fpm config file is installed.
-  template:
-    src: php-fpm.conf.j2
-    dest: "{{ php_fpm_conf_path }}/php-fpm.conf"
-    mode: 0644
-  when: "'--enable-fpm' in php_source_configure_command"
-  notify: restart php-fpm

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -141,5 +141,3 @@
     mode: 0755
   when: "'--enable-fpm' in php_source_configure_command"
   notify: restart php-fpm
-
-

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -10,3 +10,4 @@ include={{ php_fpm_conf_path }}/pool.d/*.conf
 
 [global]
 error_log = /var/log/php-fpm.log
+{{ php_fpm_global_options }}

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -1,3 +1,5 @@
+; {{ ansible_managed }}
+
 ;;;;;;;;;;;;;;;;;;;;;
 ; FPM Configuration ;
 ;;;;;;;;;;;;;;;;;;;;;
@@ -9,5 +11,4 @@ include={{ php_fpm_conf_path }}/pool.d/*.conf
 ;;;;;;;;;;;;;;;;;;
 
 [global]
-error_log = /var/log/php-fpm.log
 {{ php_fpm_global_options }}


### PR DESCRIPTION
Right now php-fpm.conf is only created when installing from source.

This will enable the ability to customize the php-fpm.conf global options