### PR TITLE
Add php_fpm_memory_limit variable to www.conf.j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
     php_display_errors: "Off"
     php_display_startup_errors: "On"
+    php_error_log: "/var/log/php-errors.log"
     php_expose_php: "On"
     php_session_cookie_lifetime: 0
     php_session_gc_probability: 1

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The handler restarts PHP-FPM by default. Setting the value to `reloaded` will re
     php_fpm_pm_start_servers: 5
     php_fpm_pm_min_spare_servers: 5
     php_fpm_pm_max_spare_servers: 5
+	php_fpm_memory_limit: "256M"
 
 Specific settings inside the default `www.conf` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template or using `lineinfile` like this role does inside `tasks/configure-fpm.yml`.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ The handler restarts PHP-FPM by default. Setting the value to `reloaded` will re
     php_fpm_pm_start_servers: 5
     php_fpm_pm_min_spare_servers: 5
     php_fpm_pm_max_spare_servers: 5
+    php_fpm_pm_max_requests: 500
 	php_fpm_memory_limit: "256M"
+	php_fpm_max_execution_time: 30
 
 Specific settings inside the default `www.conf` PHP-FPM pool. If you'd like to manage additional settings, you can do so either by replacing the file with your own template or using `lineinfile` like this role does inside `tasks/configure-fpm.yml`.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_max_input_time: "60"
     php_max_input_vars: "1000"
     php_realpath_cache_size: "32K"
+    php_realpath_cache_ttl: "120"
     php_file_uploads: "On"
     php_upload_max_filesize: "64M"
     php_max_file_uploads: "20"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,6 +92,7 @@ php_session_save_path: ''
 php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 php_display_errors: "Off"
 php_display_startup_errors: "Off"
+php_error_log: "/var/log/php-errors.log"
 
 # Install PHP from source (instead of using a package manager) with these vars.
 php_install_from_source: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+php_fpm_memory_limit: "256M"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ php_max_execution_time: "60"
 php_max_input_time: "60"
 php_max_input_vars: "1000"
 php_realpath_cache_size: "32K"
+php_realpath_cache_ttl: "120"
 
 php_file_uploads: "On"
 php_upload_max_filesize: "64M"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,9 @@ php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+php_fpm_pm_max_requests: 500
 php_fpm_memory_limit: "256M"
+php_fpm_max_execution_time: 30
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -67,8 +67,12 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
-    - regexp: '^php_value\[memory_limit\].?=.+$'
-      line: "php_value[memory_limit] = {{ php_fpm_memory_limit }}"
+    - regexp: '^pm\.max_requests.?=.+$'
+      line: "pm.max_requests = {{ php_fpm_pm_max_requests }}"
+    - regexp: '^php_admin_value\[memory_limit\].?=.+$'
+      line: "php_admin_value[memory_limit] = {{ php_fpm_memory_limit }}"
+    - regexp: '^php_admin_value\[max_execution_time\].?=.+$'
+      line: "php_admin_value[max_execution_time] = {{ php_fpm_max_execution_time }}"
   when: php_enable_php_fpm
   notify: restart php-fpm
 

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -67,6 +67,8 @@
       line: "pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}"
     - regexp: '^pm\.max_spare_servers.?=.+$'
       line: "pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}"
+    - regexp: '^php_value\[memory_limit\].?=.+$'
+      line: "php_value[memory_limit] = {{ php_fpm_memory_limit }}"
   when: php_enable_php_fpm
   notify: restart php-fpm
 

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -41,6 +41,7 @@ memory_limit = {{ php_memory_limit }}
 error_reporting = {{ php_error_reporting }}
 display_errors = {{ php_display_errors }}
 display_startup_errors = {{ php_display_startup_errors }}
+error_log = {{ php_error_log }}
 log_errors = On
 log_errors_max_len = 1024
 ignore_repeated_errors = Off

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -75,6 +75,7 @@ user_dir =
 enable_dl = Off
 
 realpath_cache_size = {{ php_realpath_cache_size }}
+realpath_cache_ttl = {{ php_realpath_cache_ttl }}
 
 ;;;;;;;;;;;;;;;;
 ; File Uploads ;

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -13,3 +13,5 @@ pm.start_servers = 5
 pm.min_spare_servers = 5
 pm.max_spare_servers = 5
 pm.max_requests = 500
+
+php_value[memory_limit] = 256M

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -14,4 +14,5 @@ pm.min_spare_servers = 5
 pm.max_spare_servers = 5
 pm.max_requests = 500
 
-php_value[memory_limit] = 256M
+php_admin_value[memory_limit] = 256M
+php_admin_value[max_execution_time] = 30


### PR DESCRIPTION
Sometimes I need to have a different memory_limit for CLI and PHP-FPM. 

So I added a new variable php_fpm_memory_limit, which allows to define memory_limit for PHP-FPM.