### PR TITLE
Feature: www pool & php 8 jit variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,10 +26,12 @@ php_fpm_handler_state: restarted
 php_fpm_enabled_on_boot: true
 php_fpm_listen: "127.0.0.1:9000"
 php_fpm_listen_allowed_clients: "127.0.0.1"
+php_fpm_pm: "dynamic"
 php_fpm_pm_max_children: 50
 php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
+php_fpm_pm_max_requests: 500
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,8 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_jit: "tracing"
+php_opcache_jit_buffer_size: "256M"
 
 # APCu settings.
 php_enable_apc: true

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -40,7 +40,6 @@
     owner: root
     group: root
     mode: 0644
-    force: false
   when: php_enable_php_fpm
 
 - name: Configure php-fpm pool (if enabled).

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -40,6 +40,7 @@
     owner: root
     group: root
     mode: 0644
+    force: true
   when: php_enable_php_fpm
 
 - name: Configure php-fpm pool (if enabled).

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -12,5 +12,9 @@ opcache.max_file_size={{ php_opcache_max_file_size }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}
+{% if php_opcache_jit != '' %}
 opcache.jit={{ php_opcache_jit }}
+{% endif %}
+{% if php_opcache_jit_buffer_size != '' %}
 opcache.jit_buffer_size={{ php_opcache_jit_buffer_size }}
+{% endif %}

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -12,3 +12,5 @@ opcache.max_file_size={{ php_opcache_max_file_size }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}
+opcache.jit={{ php_opcache_jit }}
+opcache.jit_buffer_size={{ php_opcache_jit_buffer_size }}

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -1,15 +1,15 @@
 [www]
-listen = 127.0.0.1:9000
-listen.allowed_clients = 127.0.0.1
+listen = {{ php_fpm_listen }}
+listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}
 user = {{ php_fpm_pool_user }}
 group = {{ php_fpm_pool_group }}
 
 listen.owner = {{ php_fpm_pool_user }}
 listen.group = {{ php_fpm_pool_group }}
 
-pm = dynamic
-pm.max_children = 50
-pm.start_servers = 5
-pm.min_spare_servers = 5
-pm.max_spare_servers = 5
-pm.max_requests = 500
+pm = {{ php_fpm_pm }}
+pm.max_children = {{ php_fpm_pm_max_children }}
+pm.start_servers = {{ php_fpm_pm_start_servers }}
+pm.min_spare_servers = {{ php_fpm_pm_min_spare_servers }}
+pm.max_spare_servers = {{ php_fpm_pm_max_spare_servers }}
+pm.max_requests = {{ php_fpm_pm_max_requests }}


### PR DESCRIPTION
- Update `www.conf` template to use all current variables
- Update `configure-fpm` task to overwrite `www.conf` with template every time
- Add `php_fpm_pm` and `php_fpm_pm_max_requests` variables for `www.conf` template
- Add `php_opcache_jit` and `php_opcache_jit_buffer_size` variables for `opcache.ini` template