### PR TITLE
Fix for #331

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The handler restarts PHP-FPM by default. Setting the value to `reloaded` will re
     php_fpm_pools:
       - pool_name: www
         pool_template: www.conf.j2
+        pool_file: www.conf
         pool_listen: "127.0.0.1:9000"
         pool_listen_allowed_clients: "127.0.0.1"
         pool_pm: dynamic

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ php_fpm_pm_max_requests: 0
 php_fpm_pools:
   - pool_name: www
     pool_template: www.conf.j2
+    pool_file: "{{ ( php_fpm_pool_conf_path | basename ) | default('www.conf', true) }}"
     pool_listen: "{{ php_fpm_listen }}"
     pool_listen_allowed_clients: "{{ php_fpm_listen_allowed_clients }}"
     pool_pm: dynamic

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -36,7 +36,7 @@
 - name: Create fpm pools.
   template:
     src: "{{ item.pool_template | default('www.conf.j2', true) }}"
-    dest: "{{ php_fpm_pool_conf_path | dirname }}/{{ item.pool_name }}.conf"
+    dest: "{{ php_fpm_pool_conf_path | dirname }}/{{ item.pool_file }}"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
Updates the new `php_fpm_pools` to use the `php_fpm_pool_conf_path` filename if it is set. If not fallback to www.conf

Fixes #331 