### PR TITLE
Use comment filter on ansible_managed var in www.conf

### DIFF
--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -1,4 +1,4 @@
-; {{ ansible_managed }}
+{{ ansible_managed | comment(decoration='; ') }}
 
 [{{ item.pool_name | mandatory }}]
 listen = {{ item.pool_listen | mandatory }}


### PR DESCRIPTION
When setting `ansible_managed` to a multiline value, the default www-pool file becomes invalid.
I've added the `comment` filter with a custom decoration.