### PR TITLE
[release workflow] Rename ansible-base to ansible-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible.
-        run: pip3 install ansible-base
+        run: pip3 install ansible-core
 
       - name: Trigger a new import on Galaxy.
         run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)


### PR DESCRIPTION
For Ansible 2.11 and above, `ansible-base` is now `ansible-core`. This isn't a big deal, but I saw it and figured I'd point it out. This applies to your other roles, as well.
