### PR TITLE
Variable to configure opcache.save_comments parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_max_input_time: "60"
     php_max_input_vars: "1000"
     php_realpath_cache_size: "32K"
+    php_realpath_cache_ttl: "120"
     php_file_uploads: "On"
     php_upload_max_filesize: "64M"
     php_max_file_uploads: "20"
@@ -141,6 +142,7 @@ The OpCache is included in PHP starting in version 5.5, and the following variab
     php_opcache_revalidate_path: "0"
     php_opcache_revalidate_freq: "2"
     php_opcache_max_file_size: "0"
+    php_opcache_save_comments: "0"
 
 OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,7 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_save_comments: "0"
 
 # APCu settings.
 php_enable_apc: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,6 +78,7 @@ php_max_execution_time: "60"
 php_max_input_time: "60"
 php_max_input_vars: "1000"
 php_realpath_cache_size: "32K"
+php_realpath_cache_ttl: "120"
 
 php_file_uploads: "On"
 php_upload_max_filesize: "64M"

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -9,6 +9,7 @@ opcache.validate_timestamps={{ php_opcache_validate_timestamps }}
 opcache.revalidate_path={{ php_opcache_revalidate_path }}
 opcache.revalidate_freq={{ php_opcache_revalidate_freq }}
 opcache.max_file_size={{ php_opcache_max_file_size }}
+opcache.save_comments={{ php_opcache_save_comments }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -74,6 +74,7 @@ user_dir =
 enable_dl = Off
 
 realpath_cache_size = {{ php_realpath_cache_size }}
+realpath_cache_ttl = {{ php_realpath_cache_ttl }}
 
 ;;;;;;;;;;;;;;;;
 ; File Uploads ;


### PR DESCRIPTION
Magento 2 is parsing comments meta attributes. This PR allows you to configure `opcache.save_comments` parameter.

Ref: https://devdocs.magento.com/guides/v2.4/install-gde/prereq/php-settings.html#check-php-settings
