### PR TITLE
Add support for Debian 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
             playbook: converge.yml
           - distro: ubuntu1804
             playbook: converge.yml
+          - distro: debian11
+            playbook: converge.yml
           - distro: debian10
             playbook: converge.yml
           - distro: debian9

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,2 @@
+---
+__php_default_version_debian: "7.4"


### PR DESCRIPTION
Hi @geerlingguy, I recently tried to use this library with Debian 11 and it wasn't working without this variable.
Defining the variable myself solve the build, so I suppose there is nothing more to do.