### PR TITLE
fix(php-ini): add sys_tmp_dir and upload_tmp_dir settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_file_uploads: "On"
     php_upload_max_filesize: "64M"
     php_max_file_uploads: "20"
+    php_upload_tmp_dir: NULL
     php_post_max_size: "32M"
     php_date_timezone: "America/Chicago"
     php_allow_url_fopen: "On"
@@ -123,6 +124,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_disable_functions: []
     php_precision: 14
     php_serialize_precision: "-1"
+    php_sys_temp_dir: ""
 
 Various defaults for PHP. Only used if `php_use_managed_ini` is set to `true`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,10 +77,12 @@ php_max_execution_time: "60"
 php_max_input_time: "60"
 php_max_input_vars: "1000"
 php_realpath_cache_size: "32K"
+php_sys_temp_dir: ""
 
 php_file_uploads: "On"
 php_upload_max_filesize: "64M"
 php_max_file_uploads: "20"
+php_upload_tmp_dir: NULL
 
 php_post_max_size: "32M"
 php_date_timezone: "America/Chicago"

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -19,6 +19,8 @@ disable_classes =
 
 zend.enable_gc = On
 
+sys_temp_dir = {{ php_sys_temp_dir }}/var/tmp
+
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
 ;;;;;;;;;;;;;;;;;
@@ -82,6 +84,7 @@ realpath_cache_size = {{ php_realpath_cache_size }}
 file_uploads = {{ php_file_uploads }}
 upload_max_filesize = {{ php_upload_max_filesize }}
 max_file_uploads = {{ php_max_file_uploads }}
+upload_tmp_dir = {{ php_upload_tmp_dir }}
 
 ;;;;;;;;;;;;;;;;;;
 ; Fopen wrappers ;

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -19,7 +19,7 @@ disable_classes =
 
 zend.enable_gc = On
 
-sys_temp_dir = {{ php_sys_temp_dir }}/var/tmp
+sys_temp_dir = {{ php_sys_temp_dir }}
 
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;


### PR DESCRIPTION
Hi @geerlingguy , 

First, thank you for the good documentation on the repo.

It seems that these two settings are missing in php.ini template. I know there are a lot of others without `php_SETTING` in variable so maybe there is a reason for that.

What do you think about this ?

Have a great day