### PR TITLE
Update php.ini.j2

### DIFF
--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -88,7 +88,11 @@ max_file_uploads = {{ php_max_file_uploads }}
 ;;;;;;;;;;;;;;;;;;
 
 allow_url_fopen = {{ php_allow_url_fopen }}
-allow_url_include = Off
+
+# PHP 7.4 Deprecated: https://www.php.net/manual/en/migration74.deprecated.php
+# allow_url_include INI option
+# The allow_url_include ini directive is deprecated. Enabling it will generate a deprecation notice at startup.
+# allow_url_include = Off
 
 default_socket_timeout = 60
 


### PR DESCRIPTION
PHP 7.4 Deprecated: https://www.php.net/manual/en/migration74.deprecated.php

allow_url_include INI option
The allow_url_include ini directive is deprecated. Enabling it will generate a deprecation notice at startup.