### PR TITLE
Fix default `pool_pm_max_requests` config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ php_fpm_pools:
     pool_pm_start_servers: "{{ php_fpm_pm_start_servers }}"
     pool_pm_min_spare_servers: "{{ php_fpm_pm_min_spare_servers }}"
     pool_pm_max_spare_servers: "{{ php_fpm_pm_max_spare_servers }}"
-    pool_php_fpm_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
+    pool_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"


### PR DESCRIPTION
The template `www.conf.j2` expects the variable `{{ item.pool_pm_max_requests }}`, but the default config set the variable with name `item.pool_php_fpm_pm_max_requests`.