### PR TITLE
Add pm.status_path to settings and template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 php_fpm_pm_max_requests: 0
+php_fpm_pm_status_path: ""
 
 # PHP-FPM pool configuration.
 php_fpm_pools:
@@ -44,6 +45,7 @@ php_fpm_pools:
     pool_pm_min_spare_servers: "{{ php_fpm_pm_min_spare_servers }}"
     pool_pm_max_spare_servers: "{{ php_fpm_pm_max_spare_servers }}"
     pool_php_fpm_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
+    pool_pm_status_path: "{{ php_fpm_pm_status_path }}"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -15,3 +15,4 @@ pm.start_servers = {{ item.pool_pm_start_servers | default(5, true) }}
 pm.min_spare_servers = {{ item.pool_pm_min_spare_servers | default(5, true) }}
 pm.max_spare_servers = {{ item.pool_pm_max_spare_servers | default(5, true) }}
 pm.max_requests = {{ item.pool_pm_max_requests | default(500, true) }}
+pm.status_path = {{ item.pool_pm_status_path | default('', true) }}


### PR DESCRIPTION
Adding a PR to #350 just in case. ;)

This should allow you to set a `pm.status_path` for an FPM pool. Leaving it empty should, [per the documentation](https://www.php.net/manual/en/install.fpm.configuration.php#pm.status-path), disable the feature for that pool.

Open to comments and suggestions, I'm not too experienced with Ansible templating.

Closes #350 