### PR TITLE
Fix variable name for pm.max_requests.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ php_fpm_pools:
     pool_pm_start_servers: "{{ php_fpm_pm_start_servers }}"
     pool_pm_min_spare_servers: "{{ php_fpm_pm_min_spare_servers }}"
     pool_pm_max_spare_servers: "{{ php_fpm_pm_max_spare_servers }}"
-    pool_php_fpm_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
+    pool_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"


### PR DESCRIPTION
While combing through the options, I encountered this default with a "wrong" name. This would result in pools not getting the for-all-pools value set for `pm.max_requests`, instead falling back to the default 500.