### PR TITLE
Added possibility to choose if web server is restarted or reloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If your usage of PHP is tied to a web server (e.g. Apache or Nginx), leave this 
 
 The default values for the HTTP server deamon are `httpd` (used by Apache) for RedHat/CentOS, or `apache2` (also used by Apache) for Debian/Ubuntu. If you are running another webserver (for example, `nginx`), change this value to the name of the daemon under which the webserver runs.
 
+    php_webserver_handler_state: restarted
+
+The handler restarts the web server by default. Setting the value to `reloaded` will reload the service, intead of restarting it.
+
     php_enablerepo: ""
 
 (RedHat/CentOS only) If you have enabled any additional repositories (might I suggest [geerlingguy.repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel) or [geerlingguy.repo-remi](https://github.com/geerlingguy/ansible-role-repo-remi)), those repositories can be listed under this variable (e.g. `remi-php70,epel`). This can be handy, as an example, if you want to install the latest version of PHP 7.0, which is in the Remi repository.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ php_install_recommends: true
 
 # Set this to false if you're not using PHP with Apache/Nginx/etc.
 php_enable_webserver: true
+php_webserver_handler_state: restarted
 
 # PHP-FPM configuration.
 php_enable_php_fpm: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: restart webserver
   service:
     name: "{{ php_webserver_daemon }}"
-    state: restarted
+    state: "{{ php_webserver_handler_state }}"
   notify: restart php-fpm
   when: php_enable_webserver
 


### PR DESCRIPTION
In production systems, it is sometimes better to reload web server instead of restarting it. This commit allows users to manage restart or reload of web server service, but keeps restarting it by default.

Thanks to @rsicart for #300 
