### PR TITLE
OPCache: set JIT buffer size to enable JIT compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The OpCache is included in PHP starting in version 5.5, and the following variab
     php_opcache_revalidate_path: "0"
     php_opcache_revalidate_freq: "2"
     php_opcache_max_file_size: "0"
+    php_opcache_jit_buffer_size: 100M
 
 OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,7 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_jit_buffer_size: 100M
 
 # APCu settings.
 php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -12,3 +12,4 @@ opcache.max_file_size={{ php_opcache_max_file_size }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}
+opcache.jit_buffer_size={{ php_opcache_jit_buffer_size }}


### PR DESCRIPTION
PHP8's JIT is only enabled when an explicit JIT buffer size larger than 0 is set.
This MR exposes the relevant variable through this ansible role.