### PR TITLE
Remove explicit dependency on php-json

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,7 +10,6 @@ __php_packages:
   - php{{ php_default_version_debian }}-gd
   - php{{ php_default_version_debian }}-curl
   - php{{ php_default_version_debian }}-imap
-  - php{{ php_default_version_debian }}-json
   - php{{ php_default_version_debian }}-opcache
   - php{{ php_default_version_debian }}-xml
   - php{{ php_default_version_debian }}-mbstring


### PR DESCRIPTION
This prevents the role from working on Ubuntu 20.04 with PHP 8.1 per:
```
# apt install php8.1-json
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package php8.1-json is a virtual package provided by:
  php8.1-phpdbg 8.1.2-1+ubuntu20.04.1+deb.sury.org+1
  php8.1-fpm 8.1.2-1+ubuntu20.04.1+deb.sury.org+1
  php8.1-cli 8.1.2-1+ubuntu20.04.1+deb.sury.org+1
  php8.1-cgi 8.1.2-1+ubuntu20.04.1+deb.sury.org+1
  libphp8.1-embed 8.1.2-1+ubuntu20.04.1+deb.sury.org+1
  libapache2-mod-php8.1 8.1.2-1+ubuntu20.04.1+deb.sury.org+1
You should explicitly select one to install.

E: Package 'php8.1-json' has no installation candidate
```