### PR TITLE
Add variables for Ubuntu 22

### DIFF
--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -1,0 +1,2 @@
+---
+__php_default_version_debian: "8.1"


### PR DESCRIPTION
Hey there geerlingguy,

we have started setting up Ubuntu 22.04 servers and noticed that this role breaks because of a missing variable file.
I added it and set the variable accordingly.