### PR TITLE
Fix typo (should probably be flexibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Specific settings inside the default `www.conf.j2` PHP-FPM pool. If you'd like t
 
     php_use_managed_ini: true
 
-By default, all the extra defaults below are applied through the php.ini included with this role. You can self-manage your php.ini file (if you need more flexility in its configuration) by setting this to `false` (in which case all the below variables will be ignored).
+By default, all the extra defaults below are applied through the php.ini included with this role. You can self-manage your php.ini file (if you need more flexibility in its configuration) by setting this to `false` (in which case all the below variables will be ignored).
 
     php_fpm_pool_user: "[apache|nginx|other]" # default varies by OS
     php_fpm_pool_group: "[apache|nginx|other]" # default varies by OS


### PR DESCRIPTION
flexility -> flexibility