### PR TITLE
Update configure.yml

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,7 +5,7 @@
     state: directory
     follow: true
     mode: 0755
-  with_flattened:
+  loop:
     - "{{ php_conf_paths }}"
     - "{{ php_extension_conf_paths }}"
 


### PR DESCRIPTION
fix for
fatal: [HOST]: FAILED! => {"reason": "'with_flattened' is not a valid attribute for a Task\n\nThe error appears to be in 'roles/geerlingguy.php/tasks/configure.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Ensure configuration directories exist.\n  ^ here\n\nThis error can be suppressed as a warning using the \"invalid_task_attribute_failed\" configuration\n\nThe error appears to be in 'roles/geerlingguy.php/tasks/configure.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Ensure configuration directories exist.\n  ^ here\n"}