### PR TITLE
fix(php version): Added a new variable to specify the module to be able to install a specific version of PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ The default values for the HTTP server deamon are `httpd` (used by Apache) for R
 
     php_enablerepo: ""
 
-(RedHat/CentOS only) If you have enabled any additional repositories (might I suggest [geerlingguy.repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel) or [geerlingguy.repo-remi](https://github.com/geerlingguy/ansible-role-repo-remi)), those repositories can be listed under this variable (e.g. `remi-php70,epel`). This can be handy, as an example, if you want to install the latest version of PHP 7.0, which is in the Remi repository.
+(RedHat/CentOS 7.x only) If you have enabled any additional repositories (might I suggest [geerlingguy.repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel) or [geerlingguy.repo-remi](https://github.com/geerlingguy/ansible-role-repo-remi)), those repositories can be listed under this variable (e.g. `remi-php70,epel`). This can be handy, as an example, if you want to install the latest version of PHP 7.0, which is in the Remi repository.
+
+    php_enable_dnf_module: ""
+
+(RedHat/CentOS 8.x only) On RHEL/CentOS 8.x, to install a specific version of PHP, you need to enable relative module(s) of the additional repository listing it/them under this variable (e.g. `php:remi-7.4`). 
 
     php_default_version_debian: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # for RHEL/CentOS.
 php_enablerepo: ""
 
+# Pass the module you want to enable (e.g. "php:remi-7.4"). Used only for
+# RHEL/CentOS >= 8.6.
+php_enable_dnf_module: ""
+
 # Extra packages to install (in addition to distro-specific default lists).
 php_packages_extra: []
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,14 @@
 ---
+- name: Ensure PHP default module is reset
+  shell: "dnf module reset php -y"
+  when: ansible_distribution_major_version == '8'
+
+- name: Ensure new PHP module is set
+  dnf:
+    name: "@{{ php_enable_dnf_module }}"
+    state: present
+  when: ansible_distribution_major_version == '8'
+
 - name: Ensure PHP packages are installed.
   package:
     name: "{{ php_packages + php_packages_extra }}"


### PR DESCRIPTION
**IMPORTANT**:
The molecule test  will fail. This for two reasons:
- the `geerlingguy/docker-centos8-ansible:latest` docker image is obsolete and you will have an incompatiblity with role `geerlingguy.repo-remi` (I leave the error below). You can use this, instead: `bmeme/docker-ansible-ol:8` based on Oracle Linux 8.6 (CentOs images are not more updated).
- remove `remi` from `php_enablerepo` variables in `converge.yml`.

The error I had using `geerlingguy/docker-centos8-ansible:latest`:

```
TASK [geerlingguy.repo-remi : Import remi GPG key.] ****************************
fatal: [instance]: FAILED! => {"changed": false, "msg": "failed to fetch key at https://rpms.remirepo.net/RPM-GPG-KEY-remi2018 , error was: Request failed: <urlopen error [Errno 99] Cannot assign requested address>"}
```