### PR TITLE
Adding syslog.filter in php.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_output_buffering: "4096"
     php_short_open_tag: false
     php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
+    php_syslog_filter: "all"
     php_display_errors: "Off"
     php_display_startup_errors: "On"
     php_expose_php: "On"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,7 @@ php_session_save_path: ''
 php_error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 php_display_errors: "Off"
 php_display_startup_errors: "Off"
+php_syslog_filter: "all"
 
 # Install PHP from source (instead of using a package manager) with these vars.
 php_install_from_source: false

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -41,6 +41,7 @@ memory_limit = {{ php_memory_limit }}
 error_reporting = {{ php_error_reporting }}
 display_errors = {{ php_display_errors }}
 display_startup_errors = {{ php_display_startup_errors }}
+syslog.filter = {{ php_syslog_filter }}
 log_errors = On
 log_errors_max_len = 1024
 ignore_repeated_errors = Off


### PR DESCRIPTION
Hello,
to my knowledge it is not possible to configure syslog.filter in php.ini at the moment with this playbook.
I added the variables to make it possible.

thanks