### PR TITLE
Add TTL options for APCu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,8 @@ php_opcache_blacklist_filename: ""
 php_enable_apc: true
 php_apc_shm_size: "96M"
 php_apc_enable_cli: "0"
+php_apc_ttl: "60"
+php_apc_gc_ttl: "3600"
 
 # If this is set to false, none of the following options will have any effect.
 # Any and all changes to /etc/php.ini will be your responsibility.

--- a/templates/apc.ini.j2
+++ b/templates/apc.ini.j2
@@ -1,4 +1,7 @@
 extension=apcu.so
 apc.shm_size={{ php_apc_shm_size }}
+apc.ttl={{ php_apc_ttl }}
+apc.gc_ttl={{ php_apc_gc_ttl }}
 apc.enable_cli={{ php_apc_enable_cli }}
 apc.rfc1867=1
+


### PR DESCRIPTION
This PR added two TTL options for APCu; TTL and GC_TTL.
The default value for TTL according to the docs is 0, I went with 60 however as 0 means that cached variables are immediately expired.
As for Garbage Collection the default is 3600, this is the value used.