### PR TITLE
add option to set pm.status_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The handler restarts PHP-FPM by default. Setting the value to `reloaded` will re
         pool_pm_min_spare_servers: 1
         pool_pm_max_spare_servers: 3
         pool_pm_max_requests: 500
+        pool_pm_status_path: /status
 
 List of PHP-FPM pool to create. By default, www pool is created. To setup a new pool, add an item to php_fpm_pools list.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ php_fpm_pm_start_servers: 5
 php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 php_fpm_pm_max_requests: 0
+php_fpm_pm_status_path: ""
 
 # PHP-FPM pool configuration.
 php_fpm_pools:
@@ -44,6 +45,7 @@ php_fpm_pools:
     pool_pm_min_spare_servers: "{{ php_fpm_pm_min_spare_servers }}"
     pool_pm_max_spare_servers: "{{ php_fpm_pm_max_spare_servers }}"
     pool_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
+    pool_pm_status_path: "{{ php_fpm_pm_status_path }}"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -15,3 +15,6 @@ pm.start_servers = {{ item.pool_pm_start_servers | default(5, true) }}
 pm.min_spare_servers = {{ item.pool_pm_min_spare_servers | default(5, true) }}
 pm.max_spare_servers = {{ item.pool_pm_max_spare_servers | default(5, true) }}
 pm.max_requests = {{ item.pool_pm_max_requests | default(500, true) }}
+{% if item.pool_pm_status_path|length %}
+pm.status_path = {{ item.pool_pm_status_path }}
+{% endif %}


### PR DESCRIPTION
Makes it possible to define a status_path. The default value is empty, and in that case the setting will not be written to the config file, i.e. no change to default behaviour.

for your consideration @geerlingguy 