### PR TITLE
fix with_flattened

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,16 +1,16 @@
 ---
 - name: Ensure configuration directories exist.
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     follow: true
     mode: 0755
-  with_flattened:
-    - "{{ php_conf_paths }}"
-    - "{{ php_extension_conf_paths }}"
+  with_items:
+    - "{{ php_conf_paths | flatten }}"
+    - "{{ php_extension_conf_paths | flatten }}"
 
 - name: Place PHP configuration file in place.
-  template:
+  ansible.builtin.template:
     src: php.ini.j2
     dest: "{{ item }}/php.ini"
     owner: root


### PR DESCRIPTION
Current Ansible version that is for example in AWX does not have `with_flattened` anymore.
The fix is rather simple, but i would recommend that you check your other (great) ansible roles too.

BTW i have also corrected module names to fully qualified names, as recommended by current ansible-lint - at least for this file only. Hope this will be OK.

Ps. I wondered if for those variables we need to flatten at all, since those are plain, non-nested lists and you use them inside {{}} brackets. Anyway i did apply flatten as it won't hurt.

Ps. really great set of ansible roles - very well thought.