### PR TITLE
Only install the JSON extension on Debian for PHP 7.4 and below

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,16 @@
     php_default_version_debian: "{{ __php_default_version_debian }}"
   when: php_default_version_debian is not defined and ansible_os_family == 'Debian'
 
+- name: Define the name of the JSON extension package on Debian for PHP <8.
+  set_fact:
+    __php_json_package_debian: "{{ 'php' + php_default_version_debian + '-json' }}"
+  when: ansible_os_family == 'Debian' and php_default_version_debian is version('8.0', '<')
+
+- name: Add the JSON extension on Debian for PHP <8.
+  set_fact:
+    __php_packages: "{{ __php_packages + [__php_json_package_debian] }}"
+  when: __php_json_package_debian is defined and __php_json_package_debian not in __php_packages
+
 - name: Define php_packages.
   set_fact:
     php_packages: "{{ __php_packages | list }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,7 +9,6 @@ __php_packages:
   - php{{ php_default_version_debian }}-gd
   - php{{ php_default_version_debian }}-curl
   - php{{ php_default_version_debian }}-imap
-  - php{{ php_default_version_debian }}-json
   - php{{ php_default_version_debian }}-opcache
   - php{{ php_default_version_debian }}-xml
   - php{{ php_default_version_debian }}-mbstring


### PR DESCRIPTION
Starting with PHP 8.0 the JSON extension is part of the base package and cannot be installed separately.

Fixes #358