### PR TITLE
add support for Ubuntu 22.04 (jammy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         include:
           - distro: rockylinux8
             playbook: converge.yml
+          - distro: ubuntu2204
+            playbook: converge.yml
           - distro: ubuntu2004
             playbook: converge.yml
           - distro: ubuntu1804

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,9 +21,10 @@ galaxy_info:
         - all
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
+        - focal
+        - jammy
   galaxy_tags:
     - development
     - web

--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -1,0 +1,2 @@
+---
+__php_default_version_debian: "8.1"


### PR DESCRIPTION
...and remove trusty from meta file since it is already no longer supported

/cc @geerlingguy 