### PR TITLE
Do not run php-fpm service when ansible is in check mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,3 +13,4 @@
   when:
     - php_enable_php_fpm
     - php_fpm_state == 'started'
+    - not ansible_check_mode

--- a/tasks/configure-fpm.yml
+++ b/tasks/configure-fpm.yml
@@ -50,4 +50,7 @@
     name: "{{ php_fpm_daemon }}"
     state: "{{ php_fpm_state }}"
     enabled: "{{ php_fpm_enabled_on_boot }}"
-  when: php_enable_php_fpm and ansible_distribution != "Debian"
+  when:
+  - php_enable_php_fpm
+  - ansible_distribution != "Debian"
+  - not ansible_check_mode


### PR DESCRIPTION
At the moment running the role when in check mode always fails since the role is trying to start/restart `php-fpm` service. This will never succeed in check mode since no real changes are made to the target environment. 

This change ensures that both `restart php-fpm` and `Ensure php-fpm is started and enabled at boot (if configured).` do not run in check mode.

Below is steps I took to reproduce the issue on Ubuntu 20.04

- Run ` ansible-playbood --check --diff`

Output:

```TASK [geerlingguy.php : Ensure php-fpm is started and enabled at boot (if configured).] ***

fatal: [***]: FAILED! => {"changed": false, "msg": "Could not find the requested service php8.1-fpm: host"}
```

Definition:

```
php_default_version: "8.1"

    become: true
    daemon_reload: yes
    vars:
      php_fpm_daemon: "php8.1-fpm"
      php_default_version_debian: "{{ php_default_version }}"
      php_enable_php_fpm: true
      ...
      php_webserver_daemon: "nginx"
      php_fpm_listen: "/var/run/php/php-fpm.sock"
      php_packages:
        - php
        - ...
        - etc
```

Environment:

```
- name: Print Distribution Info
  debug:
    msg: "{{ ansible_distribution }} || {{ ansible_distribution_version }} || ({{ ansible_architecture }})"
  become: true


ok: [***] => {
    "msg": "Ubuntu || 20.04 || (x86_64)"
}
```