### PR TITLE
Add opcache.jit_buffer_size and opcache.jit into opcache.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The OpCache is included in PHP starting in version 5.5, and the following variab
     php_opcache_revalidate_path: "0"
     php_opcache_revalidate_freq: "2"
     php_opcache_max_file_size: "0"
+    php_opcache_jit_buffer_size: "0"
+    php_opcache_jit: "disabled"
 
 OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,8 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_jit_buffer_size: "0"
+php_opcache_jit: "disabled"
 
 # APCu settings.
 php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -9,6 +9,10 @@ opcache.validate_timestamps={{ php_opcache_validate_timestamps }}
 opcache.revalidate_path={{ php_opcache_revalidate_path }}
 opcache.revalidate_freq={{ php_opcache_revalidate_freq }}
 opcache.max_file_size={{ php_opcache_max_file_size }}
+{% if php_opcache_jit_buffer_size != '0' %}
+opcache.jit_buffer_size={{ php_opcache_jit_buffer_size }}
+opcache.jit={{ php_opcache_jit }}
+{% endif %}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}


### PR DESCRIPTION
Hi, @geerlingguy 
To enable and set PHP JIT, I added two `opcache.jit_buffer_size` and `opcache.jit` in `opcache.ini` file.