### PR TITLE
add realpath_cache_ttl & opcache.preload with user

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ By default, all the extra defaults below are applied through the php.ini include
     php_max_input_time: "60"
     php_max_input_vars: "1000"
     php_realpath_cache_size: "32K"
+    php_realpath_cache_ttl: "120"
     php_file_uploads: "On"
     php_upload_max_filesize: "64M"
     php_max_file_uploads: "20"
@@ -142,6 +143,8 @@ The OpCache is included in PHP starting in version 5.5, and the following variab
     php_opcache_revalidate_path: "0"
     php_opcache_revalidate_freq: "2"
     php_opcache_max_file_size: "0"
+    php_opcache_preload: ""
+    php_opcache_preload_user: ""
 
 OpCache ini directives that are often customized on a system. Make sure you have enough memory and file slots allocated in the OpCache (`php_opcache_memory_consumption`, in MB, and `php_opcache_max_accelerated_files`) to contain all the PHP code you are running. If not, you may get less-than-optimal performance!
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,8 @@ php_opcache_revalidate_path: "0"
 php_opcache_revalidate_freq: "2"
 php_opcache_max_file_size: "0"
 php_opcache_blacklist_filename: ""
+php_opcache_preload: ""
+php_opcache_preload_user: ""
 
 # APCu settings.
 php_enable_apc: true
@@ -79,6 +81,7 @@ php_max_execution_time: "60"
 php_max_input_time: "60"
 php_max_input_vars: "1000"
 php_realpath_cache_size: "32K"
+php_realpath_cache_ttl: "120"
 
 php_file_uploads: "On"
 php_upload_max_filesize: "64M"

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -12,3 +12,9 @@ opcache.max_file_size={{ php_opcache_max_file_size }}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}
+{% if php_opcache_preload != '' %}
+opcache.preload={{ php_opcache_preload }}
+{% endif %}
+{% if php_opcache_preload_user != '' %}
+opcache.preload_user={{ php_opcache_preload_user }}
+{% endif %}

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -74,6 +74,7 @@ user_dir =
 enable_dl = Off
 
 realpath_cache_size = {{ php_realpath_cache_size }}
+realpath_cache_ttl = {{ php_realpath_cache_ttl }}
 
 ;;;;;;;;;;;;;;;;
 ; File Uploads ;


### PR DESCRIPTION
This PR adds configurable:

- php_realpath_cache_ttl - as cache_size is already there this makes sense
- opcache.preload - file(s) for inclusion, default is "no value"
- opcache.preload_user - for different OS users, default is "no value"

Variables added in defaults and Readme as well.

Please check and give feedback - thanks!