### PR TITLE
feat: allow the configuration of any opcache variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ For custom opcache.so location provide full path with `php_opcache_zend_extensio
 
 The platform-specific opcache configuration filename. Generally the default should work, but in some cases, you may need to override the filename.
 
+Additionally, any variable matching the `^php_opcache_.*$` regex will be converted into the corresponding opcache ini variable. \
+For instance, `php_opcache_jit_buffer_size: 256` will automatically be converted into `opcache.jit_buffer_size=256` in the opcache ini file.
+
 ### APCu-related Variables
 
     php_enable_apc: true

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -1,14 +1,7 @@
 zend_extension={{ php_opcache_zend_extension }}
-opcache.enable={{ php_opcache_enable }}
-opcache.enable_cli={{ php_opcache_enable_cli }}
-opcache.memory_consumption={{ php_opcache_memory_consumption }}
-opcache.interned_strings_buffer={{ php_opcache_interned_strings_buffer }}
-opcache.max_accelerated_files={{ php_opcache_max_accelerated_files }}
-opcache.max_wasted_percentage={{ php_opcache_max_wasted_percentage }}
-opcache.validate_timestamps={{ php_opcache_validate_timestamps }}
-opcache.revalidate_path={{ php_opcache_revalidate_path }}
-opcache.revalidate_freq={{ php_opcache_revalidate_freq }}
-opcache.max_file_size={{ php_opcache_max_file_size }}
+{% for key, var in opcache_vars.items() %}
+opcache.{{ key }}={{ var }}
+{% endfor %}
 {% if php_opcache_blacklist_filename != '' %}
 opcache.blacklist_filename={{ php_opcache_blacklist_filename }}
 {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,13 @@
+__opcache_var_names: "{{ lookup('varnames',
+                                '^php_opcache_(?!(zend_extension|conf_filename|blacklist_filename)).*$',
+                                wantlist=True) }}"
+__opcache_var_values: "{{ lookup('vars',
+                                 *__opcache_var_names,
+                                 wantlist=True) }}"
+opcache_vars: "{{ __opcache_var_names
+                    | map('regex_replace', '^(php_opcache_)', '')
+                    | map('community.general.dict_kv', 'key')
+                  | zip(__opcache_var_values
+                        | map('community.general.dict_kv', 'value'))
+                  | map('combine')
+                  | items2dict }}"


### PR DESCRIPTION
This removes the need to update the role to support new opcache variables.