### PR TITLE
Allow isolation of php-fpm pools by specifying user/group ownership, and optional chroot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,7 @@ php_apc_enable_cli: "0"
 # If this is set to false, none of the following options will have any effect.
 # Any and all changes to /etc/php.ini will be your responsibility.
 php_use_managed_ini: true
+php_ini_template: "php.ini.j2"
 
 php_expose_php: "On"
 php_memory_limit: "256M"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -11,7 +11,7 @@
 
 - name: Place PHP configuration file in place.
   ansible.builtin.template:
-    src: php.ini.j2
+    src: "{{ php_ini_template }}"
     dest: "{{ item }}/php.ini"
     owner: root
     group: root

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -3,11 +3,11 @@
 [{{ item.pool_name | mandatory }}]
 listen = {{ item.pool_listen | mandatory }}
 listen.allowed_clients = {{ item.pool_listen_allowed_clients | default('127.0.0.1', true) }}
-user = {{ php_fpm_pool_user }}
-group = {{ php_fpm_pool_group }}
+user = {{ item.pool_user | default( php_fpm_pool_user ) }}
+group = {{ item.pool_group | default( php_fpm_pool_group ) }}
 
-listen.owner = {{ php_fpm_pool_user }}
-listen.group = {{ php_fpm_pool_group }}
+listen.owner = {{ item.pool_user | default( php_fpm_pool_user ) }}
+listen.group = {{ item.pool_group | default( php_fpm_pool_group ) }}
 
 pm = {{ item.pool_pm | default('dynamic', true) }}
 pm.max_children = {{ item.pool_pm_max_children | default(50, true) }}
@@ -17,4 +17,8 @@ pm.max_spare_servers = {{ item.pool_pm_max_spare_servers | default(5, true) }}
 pm.max_requests = {{ item.pool_pm_max_requests | default(500, true) }}
 {% if item.pool_pm_status_path|length %}
 pm.status_path = {{ item.pool_pm_status_path }}
+{% endif %}
+{% if item.pool_chroot | default(false) %}chroot = {{ item.pool_chroot }}
+{% endif %}
+{% if item.pool_chdir | default(false) %}chdir = {{ item.pool_chdir }}
 {% endif %}


### PR DESCRIPTION
To improve security in multi-user systems, it should be possible to isolate users from each other in chrooted PHP-FPM pools. 

This PR therefore allows each item in the `php_fpm_pools` list to have a user and group specified, and also optionally, to have a chroot directory configured for better isolation.