### PR TITLE
Allow user to override php.ini.j2 template file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,7 @@ php_apc_enable_cli: "0"
 # If this is set to false, none of the following options will have any effect.
 # Any and all changes to /etc/php.ini will be your responsibility.
 php_use_managed_ini: true
+php_ini_template: "php.ini.j2"
 
 php_expose_php: "On"
 php_memory_limit: "256M"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -11,7 +11,7 @@
 
 - name: Place PHP configuration file in place.
   ansible.builtin.template:
-    src: php.ini.j2
+    src: "{{ php_ini_template }}"
     dest: "{{ item }}/php.ini"
     owner: root
     group: root


### PR DESCRIPTION
Other templates such as www.conf.j2 can already be overridden by the user. Allow the php.ini.j2 template file to be overridden too.