### PR TITLE
fix: don't configure fpm if not enabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,3 +85,4 @@
 - include_tasks: configure-apcu.yml
 - include_tasks: configure-opcache.yml
 - include_tasks: configure-fpm.yml
+  when: php_enable_php_fpm


### PR DESCRIPTION
Currently fpm folder structure is created even when php_enable_php_fpm is false.  