### PR TITLE
Updates the ci to run rocky9 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,8 @@ jobs:
     strategy:
       matrix:
         include:
-          # See: https://github.com/geerlingguy/ansible-role-php/issues/434
-          # - distro: rockylinux9
-          #   playbook: converge.yml
+          - distro: rockylinux9
+            playbook: converge.yml
           - distro: ubuntu2404
             playbook: converge.yml
           - distro: ubuntu2204


### PR DESCRIPTION
Closes issue #434; I think it healed itself. I can't reproduce the bug locally or when the ci.yml action runs on Github. Possible there was an issue with dependency versions on Feb 12 that have been sorted now.