### PR TITLE
Add php-fpm ping support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,8 @@ php_fpm_pools:
     pool_pm_max_spare_servers: "{{ php_fpm_pm_max_spare_servers }}"
     pool_pm_max_requests: "{{ php_fpm_pm_max_requests }}"
     pool_pm_status_path: "{{ php_fpm_pm_status_path }}"
+    pool_ping_path: ""
+    pool_ping_response: "pong"
 
 # The executable to run when calling PHP from the command line.
 php_executable: "php"

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -18,3 +18,7 @@ pm.max_requests = {{ item.pool_pm_max_requests | default(500, true) }}
 {% if item.pool_pm_status_path|length %}
 pm.status_path = {{ item.pool_pm_status_path }}
 {% endif %}
+{% if item.pool_ping_path|length %}
+ping.path = {{ item.pool_ping_path }}
+ping.response = {{ pool_ping_response | default('pong', true) }}
+{% endif %}


### PR DESCRIPTION
As per documentation, ping could be used to test from outside that FPM is alive and responding.