### PR TITLE
Add Debian 13 support

### DIFF
--- a/vars/Debian-13.yml
+++ b/vars/Debian-13.yml
@@ -1,0 +1,2 @@
+---
+__php_default_version_debian: "8.4"


### PR DESCRIPTION
Debian 13 default php version is 8.4