### PR TITLE
Bugfix/php8.4 and up imap removal

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,16 @@
     __php_packages: "{{ __php_packages + [__php_json_package_debian] }}"
   when: __php_json_package_debian is defined and __php_json_package_debian not in __php_packages
 
+- name: Define the name of the IMAP extension package on Debian for PHP <8.4.
+  set_fact:
+    __php_imap_package_debian: "{{ 'php' + php_default_version_debian + '-imap' }}"
+  when: ansible_facts.os_family == 'Debian' and php_default_version_debian is version('8.4', '<')
+
+- name: Add the IMAP extension on Debian for PHP <8.4.
+  set_fact:
+    __php_packages: "{{ __php_packages + [__php_imap_package_debian] }}"
+  when: __php_imap_package_debian is defined and __php_imap_package_debian not in __php_packages
+
 - name: Define php_packages.
   set_fact:
     php_packages: "{{ __php_packages | list }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,7 +8,6 @@ __php_packages:
   - libpcre3-dev
   - php{{ php_default_version_debian }}-gd
   - php{{ php_default_version_debian }}-curl
-  - php{{ php_default_version_debian }}-imap
   - php{{ php_default_version_debian }}-opcache
   - php{{ php_default_version_debian }}-xml
   - php{{ php_default_version_debian }}-mbstring


### PR DESCRIPTION
The IMAP extension has been removed from PHP from version 8.4.

Install candidates have since been removed from Debian unstable.

See: https://tracker.debian.org/news/1672837/removed-3103-1-from-unstable/

2nd commit - based upon PR #402 - installs the extension if the PHP version is lower than 8.4.

Fixes issue #444 