### PR TITLE
Bugfix/php8.5 opcache removal

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,16 @@
     __php_packages: "{{ __php_packages + [__php_json_package_debian] }}"
   when: __php_json_package_debian is defined and __php_json_package_debian not in __php_packages
 
+- name: Define the name of the OPcache extension package on Debian for PHP <8.5.
+  set_fact:
+    __php_opcache_package_debian: "{{ 'php' + php_default_version_debian + '-opcache' }}"
+  when: ansible_facts.os_family == 'Debian' and php_default_version_debian is version('8.5', '<')
+
+- name: Add the OPcache extension on Debian for PHP <8.5.
+  set_fact:
+    __php_packages: "{{ __php_packages + [__php_opcache_package_debian] }}"
+  when: __php_opcache_package_debian is defined and __php_opcache_package_debian not in __php_packages
+
 - name: Define php_packages.
   set_fact:
     php_packages: "{{ __php_packages | list }}"

--- a/templates/opcache.ini.j2
+++ b/templates/opcache.ini.j2
@@ -1,4 +1,6 @@
+{% if ansible_facts.os_family == 'Debian' and php_default_version_debian is version('8.5', '<') %}
 zend_extension={{ php_opcache_zend_extension }}
+{% endif %}
 opcache.enable={{ php_opcache_enable }}
 opcache.enable_cli={{ php_opcache_enable_cli }}
 opcache.memory_consumption={{ php_opcache_memory_consumption }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,7 +9,6 @@ __php_packages:
   - php{{ php_default_version_debian }}-gd
   - php{{ php_default_version_debian }}-curl
   - php{{ php_default_version_debian }}-imap
-  - php{{ php_default_version_debian }}-opcache
   - php{{ php_default_version_debian }}-xml
   - php{{ php_default_version_debian }}-mbstring
   - php{{ php_default_version_debian }}-apcu


### PR DESCRIPTION
Since PHP 8.5, OPcache has been baked in. Meaning that `php{8.5}-opcache` no longer has an install candidate on Debian unstable.

The PR removes `-opcache` from the list of packages to be installed. But then attempts to install it via `tasks/main.yml` if the version of PHP < 8.5.

Additionally, the `opcache.so` binary will not be available. The `opcache.ini` template omits referencing the binary unless the version of PHP is < 8.5.

Note that the README.md still refers to opcache.so as I am not sure how you would want to document the change in PHP 8.5 (line 134):

```yml
php_opcache_zend_extension: "opcache.so"
```

PR #402 used for inspiration.

Fixes issue #446 